### PR TITLE
Add support for pasmo symbolic tables

### DIFF
--- a/src/SymbolManager.cpp
+++ b/src/SymbolManager.cpp
@@ -123,12 +123,13 @@ void SymbolManager::addFile()
 	// create dialog
 	QFileDialog* d = new QFileDialog(this);
 	QStringList types;
-	types << "All supported files (*.sym *.map)"
+	types << "All supported files (*.sym *.map *.symbol *.publics *.sys)"
 	      << "tniASM 0.x symbol files (*.sym)"
 	      << "tniASM 1.x symbol files (*.sym)"
 	      << "asMSX 0.x symbol files (*.sym)"
 	      << "HiTech C symbol files (*.sym)"
-	      << "HiTech C link map files (*.map)";
+	      << "HiTech C link map files (*.map)"
+	      << "pasmo symbol files (*.symbol *.publics *.sys)";
 	d->setNameFilters(types);
 	d->setAcceptMode(QFileDialog::AcceptOpen);
 	d->setFileMode(QFileDialog::ExistingFile);
@@ -150,6 +151,8 @@ void SymbolManager::addFile()
 			read = symTable.readFile(n, SymbolTable::HTC_FILE);
 		} else if (f.startsWith("HiTech C link")) {
 			read = symTable.readFile(n, SymbolTable::LINKMAP_FILE);
+		} else if (f.startsWith("pasmo")) {
+			read = symTable.readFile(n, SymbolTable::PASMO_FILE);
 		} else {
 			read = symTable.readFile(n);
 		}

--- a/src/SymbolTable.cpp
+++ b/src/SymbolTable.cpp
@@ -209,6 +209,16 @@ bool SymbolTable::readFile(const QString& filename, FileType type)
 					type = HTC_FILE;
 				}
 			}
+		} else {
+			QString ext = filename.toLower();	
+			/* They are the same type of file. For some reason the Debian
+			 * manpage uses the extension ".sys" 
+			 * pasmo doc -> pasmo [options] file.asm file.bin [file.symbol [file.publics] ]
+			 * pasmo manpage in Debian -> pasmo [options]  file.asm file.bin [file.sys]
+			*/
+			if (ext.endsWith(".symbol") || ext.endsWith(".publics") || ext.endsWith(".sys") ) {
+				type = PASMO_FILE;
+			}
 		}
 	}
 	switch (type) {
@@ -224,6 +234,8 @@ bool SymbolTable::readFile(const QString& filename, FileType type)
 		return readHTCFile(filename);
 	case LINKMAP_FILE:
 		return readLinkMapFile(filename);
+	case PASMO_FILE:
+		return readPASMOFile(filename);
 	default:
 		return false;
 	}
@@ -335,6 +347,30 @@ bool SymbolTable::readASMSXFile(const QString& filename)
 				}
 			}
 		}
+	}
+	return true;
+}
+
+bool SymbolTable::readPASMOFile(const QString& filename)
+{
+	QFile file( filename );
+	if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+		return false;
+	}
+	appendFile(filename, ASMSX_FILE);
+	QTextStream in(&file);
+	while (!in.atEnd()) {
+		QString line;	
+		QStringList l;
+		Symbol* sym;
+		line = in.readLine();
+		l = line.split(QRegExp("(\t+)|( +)"));
+		if (l.size() == 3) {
+			sym = new Symbol(l.at(0), l.at(2).left(5).toInt(0, 16));
+			sym->setSource(&symbolFiles.back().fileName);
+			add(sym);
+		} else
+			return false;
 	}
 	return true;
 }

--- a/src/SymbolTable.cpp
+++ b/src/SymbolTable.cpp
@@ -357,7 +357,7 @@ bool SymbolTable::readPASMOFile(const QString& filename)
 	if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
 		return false;
 	}
-	appendFile(filename, ASMSX_FILE);
+	appendFile(filename, PASMO_FILE);
 	QTextStream in(&file);
 	while (!in.atEnd()) {
 		QString line;	

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -82,7 +82,8 @@ public:
 		SJASM_FILE,
 		ASMSX_FILE,
 		LINKMAP_FILE,
-		HTC_FILE
+		HTC_FILE,
+		PASMO_FILE
 	};
 
 	SymbolTable();
@@ -129,6 +130,7 @@ private:
 	bool readSJASMFile(const QString& filename);
 	bool readHTCFile(const QString& filename);
 	bool readLinkMapFile(const QString& filename);
+	bool readPASMOFile(const QString& filename);
 
 	void mapSymbol(Symbol* symbol);
 	void unmapSymbol(Symbol* symbol);


### PR DESCRIPTION
There is not really an specific file extension because is the user of the assembler who give the filename. I used the extension names I found in the pasmo documentation and the man pages from Debian.