### PR TITLE
MacOS visual updates

### DIFF
--- a/build/package-darwin/Info.plist
+++ b/build/package-darwin/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>NSRequiresAquaSystemAppearance</key>
 	<true/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 	<key>CFBundleExecutable</key>
 	<string>openmsx-debugger</string>
 	<key>CFBundleGetInfoHTML</key>

--- a/build/package-darwin/Info.plist
+++ b/build/package-darwin/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<true/>
 	<key>CFBundleExecutable</key>
 	<string>openmsx-debugger</string>
 	<key>CFBundleGetInfoHTML</key>

--- a/build/package-darwin/Info.plist
+++ b/build/package-darwin/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
1. Disable the dark theme for the debugger. It looks rather messed up when half of the UI elements are dark and the other is not. (The dark theme was introduced in macOS 10.14.)

Before:
<img width="1144" alt="schermafbeelding 2018-12-02 om 18 14 20" src="https://user-images.githubusercontent.com/772052/49342633-3b79d900-f65e-11e8-9be5-cef476e877e9.png">
After:
<img width="1144" alt="schermafbeelding 2018-12-02 om 18 15 03" src="https://user-images.githubusercontent.com/772052/49342634-42085080-f65e-11e8-8028-2348664f23b4.png">

2. Enable retina support so that everything appears sharp rather than upscaled. I have not seen any issues caused by enabling this.

Before:
<img width="1144" alt="schermafbeelding 2018-12-02 om 18 15 03" src="https://user-images.githubusercontent.com/772052/49342634-42085080-f65e-11e8-8028-2348664f23b4.png">
After:
<img width="1144" alt="schermafbeelding 2018-12-02 om 18 17 09" src="https://user-images.githubusercontent.com/772052/49342679-8267ce80-f65e-11e8-88e2-5bece61a9837.png">