### PR TITLE
Allow bitmap display of Expansion RAM data.

### DIFF
--- a/src/BitMapViewer.cpp
+++ b/src/BitMapViewer.cpp
@@ -179,6 +179,11 @@ void BitMapViewer::setPages()
 		showPage->insertItem(2, "2");
 		showPage->insertItem(3, "3");
 	}
+	//allow display of expansion RAM data.
+	if (VDPDataStore::instance().getVRAMSize() > 0x20000) {
+		showPage->insertItem(4, "E0");
+		showPage->insertItem(5, "E1");
+	}
 }
 
 void BitMapViewer::on_showPage_currentIndexChanged(int index)
@@ -187,7 +192,7 @@ void BitMapViewer::on_showPage_currentIndexChanged(int index)
 	// on_screenMode_currentIndexChanged we do nothing!
 	if (index == -1) return;
 
-	static const int m1[4] = { 0x00000, 0x08000, 0x10000, 0x18000 };
+	static const int m1[6] = { 0x00000, 0x08000, 0x10000, 0x18000, 0x20000, 0x28000 };
 	printf("\nvoid BitMapViewer::on_showPage_currentIndexChanged( int %i);\n", index);
 	if (screenMod >= 7) index *= 2;
 	int vramAddress = m1[index];

--- a/src/BitMapViewer.ui
+++ b/src/BitMapViewer.ui
@@ -107,6 +107,16 @@
             <string>3</string>
            </property>
           </item>
+          <item>
+           <property name="text" >
+            <string>E0</string>
+           </property>
+          </item>
+          <item>
+           <property name="text" >
+            <string>E1</string>
+           </property>
+          </item>
          </widget>
         </item>
         <item row="3" column="0" >


### PR DESCRIPTION
Even though it's not possible to directly display Expansion RAM data as a bitmap on the real thing, there is no reason it shouldn't be possible in the debugger.