### PR TITLE
Move build system to Python3

### DIFF
--- a/build/detectsys.py
+++ b/build/detectsys.py
@@ -79,18 +79,18 @@ def detectOS():
 
 if __name__ == '__main__':
 	try:
-		print >> sys.stderr, '  Using Python %s native system detection...' % (
+		print('  Using Python %s native system detection...' % (
 			python_version()
-			)
+			), file = sys.stderr)
 		hostCPU = detectCPU()
 		hostOS = detectOS()
 		if hostOS == 'mingw32' and hostCPU == 'x86_64':
 			# It is possible to run MinGW on 64-bit Windows, but producing
 			# 64-bit code is not supported yet.
 			hostCPU = 'x86'
-		print >> sys.stderr, '  Detected system: %s-%s' % (hostCPU, hostOS)
-		print 'OPENMSX_TARGET_CPU=%s' % hostCPU
-		print 'OPENMSX_TARGET_OS=%s' % hostOS
-	except ValueError, ex:
-		print >> sys.stderr, ex
+		print('  Detected system: %s-%s' % (hostCPU, hostOS), file = sys.stderr)
+		print('OPENMSX_TARGET_CPU=%s' % hostCPU)
+		print('OPENMSX_TARGET_OS=%s' % hostOS)
+	except ValueError as ex:
+		print(ex, file = sys.stderr)
 		sys.exit(1)

--- a/build/executils.py
+++ b/build/executils.py
@@ -33,10 +33,10 @@ def captureStdout(log, commandLine):
 	try:
 		proc = Popen(
 			commandParts, bufsize = -1, env = env,
-			stdin = None, stdout = PIPE, stderr = PIPE,
+			stdin = None, stdout = PIPE, stderr = PIPE, encoding = 'utf-8'
 			)
-	except OSError, ex:
-		print >> log, 'Failed to execute "%s": %s' % (commandLine, ex)
+	except OSError as ex:
+		print('Failed to execute "%s": %s' % (commandLine, ex), file = log)
 		return None
 	stdoutdata, stderrdata = proc.communicate()
 	if stderrdata:
@@ -51,7 +51,7 @@ def captureStdout(log, commandLine):
 	if proc.returncode == 0:
 		return stdoutdata
 	else:
-		print >> log, 'Execution failed with exit code %d' % proc.returncode
+		print('Execution failed with exit code %d' % proc.returncode, file = log)
 		return None
 
 def shjoin(parts):

--- a/build/gitdist.py
+++ b/build/gitdist.py
@@ -32,7 +32,7 @@ def archiveFromGit(versionedPackageName, committish):
 			)
 	try:
 		outTarPath = distBase + versionedPackageName + '.tar.gz'
-		print 'archive:', outTarPath
+		print('archive:', outTarPath)
 		if not isdir(distBase):
 			makedirs(distBase)
 		outTar = TarFile.open(outTarPath, 'w:gz')
@@ -45,11 +45,11 @@ def archiveFromGit(versionedPackageName, committish):
 				for info in inTar:
 					if exclude(info):
 						if verbose:
-							print 'EX', info.name
+							print('EX', info.name)
 						numExcluded += 1
 					else:
 						if verbose:
-							print 'IN', info.name
+							print('IN', info.name)
 						numIncluded += 1
 						info.uid = info.gid = 1000
 						info.uname = info.gname = 'openmsx'
@@ -57,8 +57,8 @@ def archiveFromGit(versionedPackageName, committish):
 						outTar.addfile(info, inTar.extractfile(info))
 			finally:
 				inTar.close()
-			print 'entries: %d included, %d excluded' % (
-					numIncluded, numExcluded)
+			print('entries: %d included, %d excluded' % (
+					numIncluded, numExcluded))
 		except:
 			# Clean up partial output file.
 			outTar.close()
@@ -72,9 +72,8 @@ def archiveFromGit(versionedPackageName, committish):
 	else:
 		data, _ = proc.communicate()
 		if len(data) != 0:
-			print >> sys.stderr, (
-					'WARNING: %d more bytes of data from "git archive" after '
-					'tar stream ended' % len(data))
+			print('WARNING: %d more bytes of data from "git archive" after '
+					'tar stream ended' % len(data), file = sys.stderr)
 
 def niceVersionFromGitDescription(description):
 	'''Our release tag names are still based on naming limitations from CVS;
@@ -106,9 +105,9 @@ def getDescription(committish):
 	try:
 		return check_output(args).rstrip('\n')
 	except CalledProcessError as ex:
-		print >> sys.stderr, '"%s" returned %d' % (
+		print('"%s" returned %d' % (
 				' '.join(args), ex.returncode
-				)
+				), file = sys.stderr)
 		raise
 
 def main(committish = None):
@@ -120,7 +119,7 @@ def main(committish = None):
 	try:
 		archiveFromGit('openmsx-debugger-%s' % version, description)
 	except (OSError, TarError) as ex:
-		print >> sys.stderr, 'ERROR: %s' % ex
+		print('ERROR: %s' % ex, sys.stderr)
 		sys.exit(1)
 
 if __name__ == '__main__':
@@ -129,5 +128,5 @@ if __name__ == '__main__':
 	elif len(sys.argv) == 2:
 		main(sys.argv[1])
 	else:
-		print >> sys.stderr, 'Usage: gitdist.py [branch | tag]'
+		print('Usage: gitdist.py [branch | tag]', file = sys.stderr)
 		sys.exit(2)

--- a/build/main.mk
+++ b/build/main.mk
@@ -19,7 +19,7 @@
 # you might have to be more specific, for example "python2" or "python2.6".
 # Or if the Python interpreter is not in the search path, you can specify its
 # full path.
-PYTHON?=python
+PYTHON?=python3
 
 
 # Logical Targets

--- a/build/msysutils.py
+++ b/build/msysutils.py
@@ -10,7 +10,7 @@ def _determineMounts():
 
 	# Figure out the root directory of MSYS.
 	proc = Popen(
-		[ msysShell(), '-c', '"%s" -c \'import sys ; print sys.argv[1]\' /'
+		[ msysShell(), '-c', '"%s" -c \'import sys ; print(sys.argv[1])\' /'
 			% sys.executable.replace('\\', '\\\\') ],
 		stdin = None,
 		stdout = PIPE,
@@ -19,9 +19,9 @@ def _determineMounts():
 	stdoutdata, stderrdata = proc.communicate()
 	if stderrdata or proc.returncode:
 		if stderrdata:
-			print >> sys.stderr, 'Error determining MSYS root:', stderrdata
+			print('Error determining MSYS root:', stderrdata, file = sys.stderr)
 		if proc.returncode:
-			print >> sys.stderr, 'Exit code %d' % proc.returncode
+			print('Exit code %d' % proc.returncode, file = sys.stderr)
 		raise IOError('Error determining MSYS root')
 	msysRoot = stdoutdata.strip()
 
@@ -41,10 +41,10 @@ def _determineMounts():
 						mounts[mountPoint] = nativePath
 			finally:
 				inp.close()
-		except IOError, ex:
-			print >> sys.stderr, 'Failed to read MSYS fstab:', ex
-		except ValueError, ex:
-			print >> sys.stderr, 'Failed to parse MSYS fstab:', ex
+		except IOError as ex:
+			print('Failed to read MSYS fstab:', ex, file = sys.stderr)
+		except ValueError as ex:
+			print('Failed to parse MSYS fstab:', ex, file = sys.stderr)
 	return mounts
 
 def msysPathToNative(path):
@@ -73,4 +73,4 @@ else:
 	msysMounts = None
 
 if __name__ == '__main__':
-	print 'MSYS mounts:', msysMounts
+	print('MSYS mounts:', msysMounts)

--- a/build/outpututils.py
+++ b/build/outpututils.py
@@ -26,12 +26,12 @@ def rewriteIfChanged(path, lines):
 			inp.close()
 
 		if newLines == oldLines:
-			print 'Up to date: %s' % path
+			print('Up to date: %s' % path)
 			return False
 		else:
-			print 'Updating %s...' % path
+			print('Updating %s...' % path)
 	else:
-		print 'Creating %s...' % path
+		print('Creating %s...' % path)
 		createDirFor(path)
 
 	out = open(path, 'w')

--- a/build/version.py
+++ b/build/version.py
@@ -28,11 +28,11 @@ def _extractRevisionFromStdout(log, command, regex):
 	# pylint 0.18.0 somehow thinks captureStdout() returns a list, not a string.
 	lines = text.split('\n') # pylint: disable-msg=E1103
 	for revision, in filterLines(lines, regex):
-		print >> log, 'Revision number found by "%s": %s' % (command, revision)
+		print('Revision number found by "%s": %s' % (command, revision), file = log)
 		return revision
 	else:
-		print >> log, 'Revision number not found in "%s" output:' % command
-		print >> log, text
+		print('Revision number not found in "%s" output:' % command, file = log)
+		print(text, file = log)
 		return None
 
 def extractGitRevision(log):
@@ -57,11 +57,11 @@ def extractRevision():
 	if not isdir('derived'):
 		makedirs('derived')
 	log = open('derived/version.log', 'w')
-	print >> log, 'Extracting revision info...'
+	print('Extracting revision info...', file = log)
 	try:
 		revision = extractGitRevision(log)
-		print >> log, 'Revision string: %s' % revision
-		print >> log, 'Revision number: %s' % extractNumberFromGitRevision(revision)
+		print('Revision string: %s' % revision, file = log)
+		print('Revision number: %s' % extractNumberFromGitRevision(revision), file = log)
 	finally:
 		log.close()
 	_cachedRevision = revision

--- a/build/version2code.py
+++ b/build/version2code.py
@@ -17,6 +17,5 @@ if __name__ == '__main__':
 	if len(sys.argv) == 2:
 		rewriteIfChanged(sys.argv[1], iterVersionInclude())
 	else:
-		print >> sys.stderr, \
-			'Usage: python version2code.py VERSION_HEADER'
+		print('Usage: python version2code.py VERSION_HEADER', file = sys.stderr)
 		sys.exit(2)

--- a/build/win_resource.py
+++ b/build/win_resource.py
@@ -21,6 +21,5 @@ if __name__ == '__main__':
 	if len(sys.argv) == 2:
 		rewriteIfChanged(sys.argv[1], iterResourceHeader())
 	else:
-		print >> sys.stderr, \
-			'Usage: python win-resource.py RESOURCE_HEADER'
+		print('Usage: python win-resource.py RESOURCE_HEADER', file = sys.stderr)
 		sys.exit(2)


### PR DESCRIPTION
This changes all the places where Python is used in the build system to use Python3 instead of Python2. It's mostly changing the syntax of print and except, and one instance of specifying an encoding to subprocess.Popen so it's a text stream instead of a binary stream.