### PR TITLE
Added a submenu to bring focus to floating widgets

### DIFF
--- a/src/DebuggerForm.h
+++ b/src/DebuggerForm.h
@@ -3,6 +3,7 @@
 
 #include "DockManager.h"
 #include "DebugSession.h"
+#include <QUuid>
 #include <QMainWindow>
 #include <QMap>
 
@@ -61,6 +62,7 @@ private:
 	QMenu* searchMenu;
 	QMenu* viewMenu;
 	QMenu* viewVDPDialogsMenu;
+	QMenu* viewFloatingWidgetsMenu;
 	QMenu* executeMenu;
 	QMenu* breakpointMenu;
 	QMenu* helpMenu;
@@ -179,8 +181,10 @@ private slots:
 	void dockWidgetVisibilityChanged(DockableWidget* w);
 	void updateViewMenu();
 	void updateVDPViewMenu();
+	void updateViewFloatingWidgetsMenu();
 	void updateWindowTitle();
 	void symbolFileChanged();
+	void showFloatingWidget();
 
 	friend class QueryPauseHandler;
 	friend class QueryBreakedHandler;


### PR DESCRIPTION
Currently floating widgets can get lost if they are behind other windows, at least on Windows, because the window manager doesn't include them on the taskbar or in the alt-tab window list.
This change adds a menu "Floating widgets" which lists all floating (undocked) widgets. Clicking on one will raise the widget to the front and focus it.
Since multiple HexViewer widgets can be created, a universally unique identifier has been added to its widget_id through Qt's QUuid.
An incremental counter might've been more efficient, but this was the easiest solution for me to achieve.
Uuids could perhaps also be created for the other widgets, if they also can also be spawned multiple times.

This is the first c++ code I've written, so apologies if I'm doing things in sub-optimal ways.

This change was made in response to this question on MRC:
«I'm developing on Windows 10, always having a lot of windows open at the same time. The debugger is constantly open as it is used "all the time :)". I'm using the Debuggable Hex Viewer a lot. Each time I choose this menu, a new window pops up (which is nice when you need more of them). But the previous one(s) are lying behind the other windows somewhere. They are of some kind of light-weight windows which I cannot locate via a menu or the like, it seems.
Is there a good way to find these windows? Or is this like a new feature request?»
https://www.msx.org/forum/msx-talk/openmsx/any-way-to-easily-find-the-debuggable-viewer-window-again