### PR TITLE
Updates button sizes for better readability.

### DIFF
--- a/src/VDPRegistersExplained.ui
+++ b/src/VDPRegistersExplained.ui
@@ -1,42 +1,43 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>VDPRegisters</class>
- <widget class="QDialog" name="VDPRegisters" >
-  <property name="geometry" >
+ <widget class="QDialog" name="VDPRegisters">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>820</width>
-    <height>777</height>
+    <width>937</width>
+    <height>826</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_4" >
+  <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
-    <widget class="QFrame" name="VDPRegistersViewer" >
-     <property name="frameShape" >
+    <widget class="QFrame" name="VDPRegistersViewer">
+     <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
-     <property name="frameShadow" >
+     <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_5" >
-      <property name="spacing" >
+     <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <property name="spacing">
        <number>0</number>
       </property>
-      <property name="leftMargin" >
+      <property name="leftMargin">
        <number>0</number>
       </property>
-      <property name="rightMargin" >
+      <property name="rightMargin">
        <number>0</number>
       </property>
       <item>
-       <spacer name="horizontalSpacer_4" >
-        <property name="orientation" >
+       <spacer name="horizontalSpacer_4">
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <property name="sizeHint" stdset="0" >
+        <property name="sizeHint" stdset="0">
          <size>
           <width>10</width>
           <height>10</height>
@@ -45,1476 +46,1485 @@
        </spacer>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_6" >
-        <property name="spacing" >
+       <layout class="QVBoxLayout" name="verticalLayout_6">
+        <property name="spacing">
          <number>9</number>
         </property>
         <item>
-         <widget class="QGroupBox" name="groupBox_Mode" >
-          <property name="title" >
+         <widget class="QGroupBox" name="groupBox_Mode">
+          <property name="title">
            <string>Mode registers</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_7" >
-           <property name="horizontalSpacing" >
-            <number>1</number>
-           </property>
-           <property name="verticalSpacing" >
-            <number>3</number>
-           </property>
-           <property name="margin" >
+          <layout class="QGridLayout" name="gridLayout_7">
+           <property name="leftMargin">
             <number>0</number>
            </property>
-           <item row="0" column="0" >
-            <widget class="QLabel" name="label_R0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>45</horstretch>
-               <verstretch>21</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>30</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="text" >
-              <string>R#0</string>
-             </property>
-             <property name="alignment" >
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1" >
-            <widget class="QLabel" name="label_val_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>21</horstretch>
-               <verstretch>21</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>30</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="focusPolicy" >
-              <enum>Qt::StrongFocus</enum>
-             </property>
-             <property name="toolTip" >
-              <string>Register 0</string>
-             </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
-             </property>
-             <property name="alignment" >
-              <set>Qt::AlignCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2" >
-            <widget class="InteractiveButton" name="pushButton_0_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="horizontalSpacing">
+            <number>1</number>
+           </property>
+           <property name="verticalSpacing">
+            <number>3</number>
+           </property>
+           <item row="1" column="5">
+            <widget class="InteractiveButton" name="pushButton_1_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="text" >
-              <string>0</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="3" >
-            <widget class="InteractiveButton" name="pushButton_0_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>tooltip set in VDPRegViewer code (VDP dependent)</string>
-             </property>
-             <property name="text" >
-              <string>DG</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="4" >
-            <widget class="InteractiveButton" name="pushButton_0_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>tooltip set in VDPRegViewer code (VDP dependent)</string>
-             </property>
-             <property name="text" >
-              <string>IE2</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="5" >
-            <widget class="InteractiveButton" name="pushButton_0_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>tooltip set in VDPRegViewer code (VDP dependent)</string>
-             </property>
-             <property name="text" >
-              <string>IE1</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="6" >
-            <widget class="InteractiveButton" name="pushButton_0_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>tooltip set in VDPRegViewer code (VDP dependent)</string>
-             </property>
-             <property name="text" >
-              <string>M5</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="7" >
-            <widget class="InteractiveButton" name="pushButton_0_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>tooltip set in VDPRegViewer code (VDP dependent)</string>
-             </property>
-             <property name="text" >
-              <string>M4</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="8" >
-            <widget class="InteractiveButton" name="pushButton_0_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>Used to change the display mode.</string>
-             </property>
-             <property name="text" >
-              <string>M3</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="9" >
-            <widget class="InteractiveButton" name="pushButton_0_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>register 0 bit 0</string>
-             </property>
-             <property name="text" >
-              <string>0</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0" >
-            <widget class="QLabel" name="label_R1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>45</horstretch>
-               <verstretch>21</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>30</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="text" >
-              <string>R#1</string>
-             </property>
-             <property name="alignment" >
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1" >
-            <widget class="QLabel" name="label_val_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>21</horstretch>
-               <verstretch>21</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>30</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="focusPolicy" >
-              <enum>Qt::StrongFocus</enum>
-             </property>
-             <property name="toolTip" >
-              <string>Register 1</string>
-             </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
-             </property>
-             <property name="alignment" >
-              <set>Qt::AlignCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="2" >
-            <widget class="InteractiveButton" name="pushButton_1_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>tooltip set in VDPRegViewer code (VDP dependent)</string>
-             </property>
-             <property name="text" >
-              <string>0</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-             <property name="flat" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="3" >
-            <widget class="InteractiveButton" name="pushButton_1_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>When 1, screen display enabled. When 0, screen disabled.</string>
-             </property>
-             <property name="text" >
-              <string>BL</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="4" >
-            <widget class="InteractiveButton" name="pushButton_1_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Enables interrupt from Horizontal scanning line by Interrupt Enable 0.</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>IE0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="5" >
-            <widget class="InteractiveButton" name="pushButton_1_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="8">
+            <widget class="InteractiveButton" name="pushButton_8_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>Used to change the display mode.</string>
-             </property>
-             <property name="text" >
-              <string>M1</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="6" >
-            <widget class="InteractiveButton" name="pushButton_1_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>Used to change the display mode.</string>
-             </property>
-             <property name="text" >
-              <string>M2</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="7" >
-            <widget class="InteractiveButton" name="pushButton_1_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="8" >
-            <widget class="InteractiveButton" name="pushButton_1_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="6">
+            <widget class="InteractiveButton" name="pushButton_0_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>When 1, sprite size is 16 x 16.  When 0, 8 x 8.</string>
+             <property name="toolTip">
+              <string>tooltip set in VDPRegViewer code (VDP dependent)</string>
              </property>
-             <property name="text" >
-              <string>SI</string>
+             <property name="text">
+              <string>IE1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="9" >
-            <widget class="InteractiveButton" name="pushButton_1_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="9">
+            <widget class="InteractiveButton" name="pushButton_8_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>Sprite expansion; when 1: expanded.  When 0, normal.</string>
+             <property name="toolTip">
+              <string>When 1, disables display of sprites.
+When 0, displays sprites.</string>
              </property>
-             <property name="text" >
-              <string>MAG</string>
+             <property name="text">
+              <string>SPD</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="0" >
-            <widget class="QLabel" name="label_R8" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="7">
+            <widget class="InteractiveButton" name="pushButton_1_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>Used to change the display mode.</string>
+             </property>
+             <property name="text">
+              <string>M2</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_R0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
-              <string>R#8</string>
+             <property name="text">
+              <string>R#0</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="2" column="1" >
-            <widget class="QLabel" name="label_val_8" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>21</horstretch>
-               <verstretch>21</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>30</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="focusPolicy" >
-              <enum>Qt::StrongFocus</enum>
-             </property>
-             <property name="toolTip" >
-              <string>Register 8</string>
-             </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
-             </property>
-             <property name="alignment" >
-              <set>Qt::AlignCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="2" >
-            <widget class="InteractiveButton" name="pushButton_8_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="9">
+            <widget class="InteractiveButton" name="pushButton_9_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>When 1, sets the color bus to input mode and enables mouse.</string>
+             <property name="toolTip">
+              <string>When 1, PAL (313 lines)
+When 0, NTSC (262 lines)
+(For RGB output only)</string>
              </property>
-             <property name="text" >
-              <string>MS</string>
+             <property name="text">
+              <string>NT</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="3" >
-            <widget class="InteractiveButton" name="pushButton_8_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="10">
+            <widget class="InteractiveButton" name="pushButton_8_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>When 1, enables light pen.  When 0, disables light pen.</string>
+             <property name="toolTip">
+              <string>When 1, sets black and white in 32 tones.
+When 0, sets color (available only with a composite encoder).</string>
              </property>
-             <property name="text" >
-              <string>LP</string>
+             <property name="text">
+              <string>BW</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="4" >
-            <widget class="InteractiveButton" name="pushButton_8_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="8">
+            <widget class="InteractiveButton" name="pushButton_1_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="5">
+            <widget class="InteractiveButton" name="pushButton_8_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
               <string>Sets the color of code 0 to the color of the palette.</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>TP</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="5" >
-            <widget class="InteractiveButton" name="pushButton_8_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="4">
+            <widget class="InteractiveButton" name="pushButton_1_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
+              <string>When 1, screen display enabled. When 0, screen disabled.</string>
+             </property>
+             <property name="text">
+              <string>BL</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="6">
+            <widget class="InteractiveButton" name="pushButton_8_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
               <string>When 1, sets the color bus to input mode.
 When 0, sets the color bus to output mode.</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>CB</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="6" >
-            <widget class="InteractiveButton" name="pushButton_8_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="4">
+            <widget class="InteractiveButton" name="pushButton_8_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
+              <string>When 1, enables light pen.  When 0, disables light pen.</string>
+             </property>
+             <property name="text">
+              <string>LP</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="8">
+            <widget class="InteractiveButton" name="pushButton_0_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>tooltip set in VDPRegViewer code (VDP dependent)</string>
+             </property>
+             <property name="text">
+              <string>M4</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_R1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>45</horstretch>
+               <verstretch>21</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>R#1</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="3">
+            <widget class="InteractiveButton" name="pushButton_9_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>When 1, sets the horizontal dot count to 212.
+When 0, sets the horizontal dot count to 192.</string>
+             </property>
+             <property name="text">
+              <string>LN</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+             <property name="flat">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="3">
+            <widget class="InteractiveButton" name="pushButton_8_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>When 1, sets the color bus to input mode and enables mouse.</string>
+             </property>
+             <property name="text">
+              <string>MS</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_R8">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>45</horstretch>
+               <verstretch>21</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>R#8</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="10">
+            <widget class="InteractiveButton" name="pushButton_1_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>Sprite expansion; when 1: expanded.  When 0, normal.</string>
+             </property>
+             <property name="text">
+              <string>MAG</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="9">
+            <widget class="InteractiveButton" name="pushButton_1_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>When 1, sprite size is 16 x 16.  When 0, 8 x 8.</string>
+             </property>
+             <property name="text">
+              <string>SI</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="6">
+            <widget class="InteractiveButton" name="pushButton_1_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>Used to change the display mode.</string>
+             </property>
+             <property name="text">
+              <string>M1</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="7">
+            <widget class="InteractiveButton" name="pushButton_9_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>When 1, interlace (Complete NTSC timing)
+When 0, non-interlace (Incomplete NTSC timing)</string>
+             </property>
+             <property name="text">
+              <string>IL</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="7">
+            <widget class="InteractiveButton" name="pushButton_0_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>tooltip set in VDPRegViewer code (VDP dependent)</string>
+             </property>
+             <property name="text">
+              <string>M5</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QLabel" name="label_val_9">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>21</horstretch>
+               <verstretch>21</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="focusPolicy">
+              <enum>Qt::StrongFocus</enum>
+             </property>
+             <property name="toolTip">
+              <string>Register 9</string>
+             </property>
+             <property name="text">
+              <string comment="testtext">FF</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="10">
+            <widget class="InteractiveButton" name="pushButton_9_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>When 1, sets *DLCLK to input mode.
+When 0, sets *DLCLK to output mode.</string>
+             </property>
+             <property name="text">
+              <string>DC</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="8">
+            <widget class="InteractiveButton" name="pushButton_9_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>When 1, displays two graphic screens interchangeably by
+                 Even field/Odd field.
+When 0, displays the same graphic screen by Even field/Odd field.</string>
+             </property>
+             <property name="text">
+              <string>E0</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="5">
+            <widget class="InteractiveButton" name="pushButton_9_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>Selects simultaneous mode.</string>
+             </property>
+             <property name="text">
+              <string>S1</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_val_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>21</horstretch>
+               <verstretch>21</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="focusPolicy">
+              <enum>Qt::StrongFocus</enum>
+             </property>
+             <property name="toolTip">
+              <string>Register 0</string>
+             </property>
+             <property name="text">
+              <string comment="testtext">FF</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="6">
+            <widget class="InteractiveButton" name="pushButton_9_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>Selects simultaneous mode.</string>
+             </property>
+             <property name="text">
+              <string>S0</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_R9">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>45</horstretch>
+               <verstretch>21</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>R#9</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="label_val_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>21</horstretch>
+               <verstretch>21</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="focusPolicy">
+              <enum>Qt::StrongFocus</enum>
+             </property>
+             <property name="toolTip">
+              <string>Register 1</string>
+             </property>
+             <property name="text">
+              <string comment="testtext">FF</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="5">
+            <widget class="InteractiveButton" name="pushButton_0_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>tooltip set in VDPRegViewer code (VDP dependent)</string>
+             </property>
+             <property name="text">
+              <string>IE2</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
+            <widget class="InteractiveButton" name="pushButton_1_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>tooltip set in VDPRegViewer code (VDP dependent)</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+             <property name="flat">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="9">
+            <widget class="InteractiveButton" name="pushButton_0_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>Used to change the display mode.</string>
+             </property>
+             <property name="text">
+              <string>M3</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="label_val_8">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>21</horstretch>
+               <verstretch>21</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="focusPolicy">
+              <enum>Qt::StrongFocus</enum>
+             </property>
+             <property name="toolTip">
+              <string>Register 8</string>
+             </property>
+             <property name="text">
+              <string comment="testtext">FF</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="4">
+            <widget class="InteractiveButton" name="pushButton_0_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>tooltip set in VDPRegViewer code (VDP dependent)</string>
+             </property>
+             <property name="text">
+              <string>DG</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="10">
+            <widget class="InteractiveButton" name="pushButton_0_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>register 0 bit 0</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="4">
+            <widget class="InteractiveButton" name="pushButton_9_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="7">
+            <widget class="InteractiveButton" name="pushButton_8_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>27</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>8</pointsize>
+              </font>
+             </property>
+             <property name="toolTip">
               <string>Selects the type of Video RAM.
 1 = 64K x 1 bit or 64K x 4 bits.
 0 = 16K x 1 bit or 16K x 4 bits.
 </string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>VR</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="7" >
-            <widget class="InteractiveButton" name="pushButton_8_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="3">
+            <widget class="InteractiveButton" name="pushButton_0_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="8" >
-            <widget class="InteractiveButton" name="pushButton_8_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>When 1, disables display of sprites.
-When 0, displays sprites.</string>
-             </property>
-             <property name="text" >
-              <string>SPD</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="9" >
-            <widget class="InteractiveButton" name="pushButton_8_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>When 1, sets black and white in 32 tones.
-When 0, sets color (available only with a composite encoder).</string>
-             </property>
-             <property name="text" >
-              <string>BW</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0" >
-            <widget class="QLabel" name="label_R9" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>45</horstretch>
-               <verstretch>21</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>30</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="text" >
-              <string>R#9</string>
-             </property>
-             <property name="alignment" >
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1" >
-            <widget class="QLabel" name="label_val_9" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>21</horstretch>
-               <verstretch>21</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>30</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="focusPolicy" >
-              <enum>Qt::StrongFocus</enum>
-             </property>
-             <property name="toolTip" >
-              <string>Register 9</string>
-             </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
-             </property>
-             <property name="alignment" >
-              <set>Qt::AlignCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="2" >
-            <widget class="InteractiveButton" name="pushButton_9_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>When 1, sets the horizontal dot count to 212.
-When 0, sets the horizontal dot count to 192.</string>
-             </property>
-             <property name="text" >
-              <string>LN</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-             <property name="flat" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="3" >
-            <widget class="InteractiveButton" name="pushButton_9_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="text" >
-              <string>0</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="4" >
-            <widget class="InteractiveButton" name="pushButton_9_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>Selects simultaneous mode.</string>
-             </property>
-             <property name="text" >
-              <string>S1</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="5" >
-            <widget class="InteractiveButton" name="pushButton_9_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>Selects simultaneous mode.</string>
-             </property>
-             <property name="text" >
-              <string>S0</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="6" >
-            <widget class="InteractiveButton" name="pushButton_9_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>When 1, interlace (Complete NTSC timing)
-When 0, non-interlace (Incomplete NTSC timing)</string>
-             </property>
-             <property name="text" >
-              <string>IL</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="7" >
-            <widget class="InteractiveButton" name="pushButton_9_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>When 1, displays two graphic screens interchangeably by
-                 Even field/Odd field.
-When 0, displays the same graphic screen by Even field/Odd field.</string>
-             </property>
-             <property name="text" >
-              <string>E0</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="8" >
-            <widget class="InteractiveButton" name="pushButton_9_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>When 1, PAL (313 lines)
-When 0, NTSC (262 lines)
-(For RGB output only)</string>
-             </property>
-             <property name="text" >
-              <string>NT</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="9" >
-            <widget class="InteractiveButton" name="pushButton_9_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
-              <font>
-               <pointsize>8</pointsize>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>When 1, sets *DLCLK to input mode.
-When 0, sets *DLCLK to output mode.</string>
-             </property>
-             <property name="text" >
-              <string>DC</string>
-             </property>
-             <property name="checkable" >
-              <bool>true</bool>
-             </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
@@ -1523,11 +1533,11 @@ When 0, sets *DLCLK to output mode.</string>
          </widget>
         </item>
         <item>
-         <spacer name="verticalSpacer_5" >
-          <property name="orientation" >
+         <spacer name="verticalSpacer_5">
+          <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
-          <property name="sizeHint" stdset="0" >
+          <property name="sizeHint" stdset="0">
            <size>
             <width>20</width>
             <height>4</height>
@@ -1536,1231 +1546,1240 @@ When 0, sets *DLCLK to output mode.</string>
          </spacer>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox_V9958" >
-          <property name="title" >
+         <widget class="QGroupBox" name="groupBox_V9958">
+          <property name="title">
            <string>V9958 Registers</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_6" >
-           <property name="horizontalSpacing" >
-            <number>1</number>
-           </property>
-           <property name="verticalSpacing" >
-            <number>3</number>
-           </property>
-           <property name="margin" >
+          <layout class="QGridLayout" name="gridLayout_6">
+           <property name="leftMargin">
             <number>0</number>
            </property>
-           <item row="0" column="0" >
-            <widget class="QLabel" name="label_R25" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="horizontalSpacing">
+            <number>1</number>
+           </property>
+           <property name="verticalSpacing">
+            <number>3</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_R25">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#25</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="0" column="1" >
-            <widget class="QLabel" name="label_val_25" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_val_25">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 25</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="0" column="2" >
-            <widget class="InteractiveButton" name="pushButton_25_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="2">
+            <widget class="InteractiveButton" name="pushButton_25_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display adjust register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="3" >
-            <widget class="InteractiveButton" name="pushButton_25_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="3">
+            <widget class="InteractiveButton" name="pushButton_25_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Video Command Mode&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">0=Normal&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">1=Screen 2-4 as screen 8&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Video Command Mode&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;0=Normal&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;1=Screen 2-4 as screen 8&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>CMD</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="4" >
-            <widget class="InteractiveButton" name="pushButton_25_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="4">
+            <widget class="InteractiveButton" name="pushButton_25_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">YJK Attribute Enable&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">0=No Attribute&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">1=With Attribute&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;YJK Attribute Enable&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;0=No Attribute&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;1=With Attribute&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>VDS</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="5" >
-            <widget class="InteractiveButton" name="pushButton_25_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="5">
+            <widget class="InteractiveButton" name="pushButton_25_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">YJK Attribute Enable&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">0=No Attribute&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">1=With Attribute&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;YJK Attribute Enable&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;0=No Attribute&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;1=With Attribute&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>YAE</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="6" >
-            <widget class="InteractiveButton" name="pushButton_25_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="6">
+            <widget class="InteractiveButton" name="pushButton_25_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">YJK Mode Enable&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">0=Normal RGB&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">1=YJK System&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;YJK Mode Enable&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;0=Normal RGB&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;1=YJK System&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>YJK</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="7" >
-            <widget class="InteractiveButton" name="pushButton_25_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="7">
+            <widget class="InteractiveButton" name="pushButton_25_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">VRAM Access Waitstates&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">0=Normal&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">1=Enable CPU Waitstate&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;VRAM Access Waitstates&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;0=Normal&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;1=Enable CPU Waitstate&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>WTE</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="8" >
-            <widget class="InteractiveButton" name="pushButton_25_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="8">
+            <widget class="InteractiveButton" name="pushButton_25_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">H-Scroll Mask 8 Pixels&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">0=Normal&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">1=Hide Leftmost Pixels&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;H-Scroll Mask 8 Pixels&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;0=Normal&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;1=Hide Leftmost Pixels&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>MSK</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="9" >
-            <widget class="InteractiveButton" name="pushButton_25_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="9">
+            <widget class="InteractiveButton" name="pushButton_25_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">H-Scroll Screen Width&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">0=One page&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">1=Two pages&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;H-Scroll Screen Width&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;0=One page&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;1=Two pages&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>SP2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="0" >
-            <widget class="QLabel" name="label_R26" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_R26">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#26</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="1" column="1" >
-            <widget class="QLabel" name="label_val_26" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="1">
+            <widget class="QLabel" name="label_val_26">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 26</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="1" column="2" >
-            <widget class="InteractiveButton" name="pushButton_26_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="2">
+            <widget class="InteractiveButton" name="pushButton_26_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display offset register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="3" >
-            <widget class="InteractiveButton" name="pushButton_26_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="3">
+            <widget class="InteractiveButton" name="pushButton_26_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display offset register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="4" >
-            <widget class="InteractiveButton" name="pushButton_26_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="4">
+            <widget class="InteractiveButton" name="pushButton_26_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">The screen is shifted &lt;span style=" font-weight:600;">TO THE LEFT&lt;/span> as specified in &lt;span style=" font-weight:600;">8-dot units&lt;/span> (16-dot units in Screen 6-7).&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">When SP2=0: Scrolling is done within one page and the non-displayed left side of the page is &lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">displayed on the right hand side of the screen (HO8 is ignored in this mode).&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">When SP2=1: Scrolling is done within 2 pages, and when scrolled, the second page appears to&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">the right habd side of the first page, and when scrolled more, the first page reappears to the right&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">of the second page.&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-weight:600; font-style:italic;">Note&lt;/span>&lt;span style=" font-style:italic;">: When SP2=1, the A15 bit of the Pattern Name table base address register should be set&lt;/span>&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-style:italic;">to "1" (VDP Reg 2, Bit 5), otherwise only the leftmost page would be displayed.&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The screen is shifted &lt;span style=&quot; font-weight:600;&quot;&gt;TO THE LEFT&lt;/span&gt; as specified in &lt;span style=&quot; font-weight:600;&quot;&gt;8-dot units&lt;/span&gt; (16-dot units in Screen 6-7).&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When SP2=0: Scrolling is done within one page and the non-displayed left side of the page is &lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;displayed on the right hand side of the screen (HO8 is ignored in this mode).&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When SP2=1: Scrolling is done within 2 pages, and when scrolled, the second page appears to&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;the right habd side of the first page, and when scrolled more, the first page reappears to the right&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;of the second page.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Note&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;: When SP2=1, the A15 bit of the Pattern Name table base address register should be set&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-style:italic;&quot;&gt;to &quot;1&quot; (VDP Reg 2, Bit 5), otherwise only the leftmost page would be displayed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H08</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="5" >
-            <widget class="InteractiveButton" name="pushButton_26_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="5">
+            <widget class="InteractiveButton" name="pushButton_26_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">The screen is shifted &lt;span style=" font-weight:600;">TO THE LEFT&lt;/span> as specified in &lt;span style=" font-weight:600;">8-dot units&lt;/span> (16-dot units in Screen 6-7).&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">When SP2=0: Scrolling is done within one page and the non-displayed left side of the page is &lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">displayed on the right hand side of the screen (HO8 is ignored in this mode).&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">When SP2=1: Scrolling is done within 2 pages, and when scrolled, the second page appears to&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">the right habd side of the first page, and when scrolled more, the first page reappears to the right&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">of the second page.&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-weight:600; font-style:italic;">Note&lt;/span>&lt;span style=" font-style:italic;">: When SP2=1, the A15 bit of the Pattern Name table base address register should be set&lt;/span>&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-style:italic;">to "1" (VDP Reg 2, Bit 5), otherwise only the leftmost page would be displayed.&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The screen is shifted &lt;span style=&quot; font-weight:600;&quot;&gt;TO THE LEFT&lt;/span&gt; as specified in &lt;span style=&quot; font-weight:600;&quot;&gt;8-dot units&lt;/span&gt; (16-dot units in Screen 6-7).&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When SP2=0: Scrolling is done within one page and the non-displayed left side of the page is &lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;displayed on the right hand side of the screen (HO8 is ignored in this mode).&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When SP2=1: Scrolling is done within 2 pages, and when scrolled, the second page appears to&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;the right habd side of the first page, and when scrolled more, the first page reappears to the right&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;of the second page.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Note&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;: When SP2=1, the A15 bit of the Pattern Name table base address register should be set&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-style:italic;&quot;&gt;to &quot;1&quot; (VDP Reg 2, Bit 5), otherwise only the leftmost page would be displayed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H07</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="6" >
-            <widget class="InteractiveButton" name="pushButton_26_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="6">
+            <widget class="InteractiveButton" name="pushButton_26_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">The screen is shifted &lt;span style=" font-weight:600;">TO THE LEFT&lt;/span> as specified in &lt;span style=" font-weight:600;">8-dot units&lt;/span> (16-dot units in Screen 6-7).&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">When SP2=0: Scrolling is done within one page and the non-displayed left side of the page is &lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">displayed on the right hand side of the screen (HO8 is ignored in this mode).&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">When SP2=1: Scrolling is done within 2 pages, and when scrolled, the second page appears to&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">the right habd side of the first page, and when scrolled more, the first page reappears to the right&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">of the second page.&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-weight:600; font-style:italic;">Note&lt;/span>&lt;span style=" font-style:italic;">: When SP2=1, the A15 bit of the Pattern Name table base address register should be set&lt;/span>&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-style:italic;">to "1" (VDP Reg 2, Bit 5), otherwise only the leftmost page would be displayed.&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The screen is shifted &lt;span style=&quot; font-weight:600;&quot;&gt;TO THE LEFT&lt;/span&gt; as specified in &lt;span style=&quot; font-weight:600;&quot;&gt;8-dot units&lt;/span&gt; (16-dot units in Screen 6-7).&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When SP2=0: Scrolling is done within one page and the non-displayed left side of the page is &lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;displayed on the right hand side of the screen (HO8 is ignored in this mode).&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When SP2=1: Scrolling is done within 2 pages, and when scrolled, the second page appears to&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;the right habd side of the first page, and when scrolled more, the first page reappears to the right&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;of the second page.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Note&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;: When SP2=1, the A15 bit of the Pattern Name table base address register should be set&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-style:italic;&quot;&gt;to &quot;1&quot; (VDP Reg 2, Bit 5), otherwise only the leftmost page would be displayed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H06</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="7" >
-            <widget class="InteractiveButton" name="pushButton_26_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="7">
+            <widget class="InteractiveButton" name="pushButton_26_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">The screen is shifted &lt;span style=" font-weight:600;">TO THE LEFT&lt;/span> as specified in &lt;span style=" font-weight:600;">8-dot units&lt;/span> (16-dot units in Screen 6-7).&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">When SP2=0: Scrolling is done within one page and the non-displayed left side of the page is &lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">displayed on the right hand side of the screen (HO8 is ignored in this mode).&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">When SP2=1: Scrolling is done within 2 pages, and when scrolled, the second page appears to&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">the right habd side of the first page, and when scrolled more, the first page reappears to the right&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">of the second page.&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-weight:600; font-style:italic;">Note&lt;/span>&lt;span style=" font-style:italic;">: When SP2=1, the A15 bit of the Pattern Name table base address register should be set&lt;/span>&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-style:italic;">to "1" (VDP Reg 2, Bit 5), otherwise only the leftmost page would be displayed.&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The screen is shifted &lt;span style=&quot; font-weight:600;&quot;&gt;TO THE LEFT&lt;/span&gt; as specified in &lt;span style=&quot; font-weight:600;&quot;&gt;8-dot units&lt;/span&gt; (16-dot units in Screen 6-7).&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When SP2=0: Scrolling is done within one page and the non-displayed left side of the page is &lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;displayed on the right hand side of the screen (HO8 is ignored in this mode).&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When SP2=1: Scrolling is done within 2 pages, and when scrolled, the second page appears to&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;the right habd side of the first page, and when scrolled more, the first page reappears to the right&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;of the second page.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Note&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;: When SP2=1, the A15 bit of the Pattern Name table base address register should be set&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-style:italic;&quot;&gt;to &quot;1&quot; (VDP Reg 2, Bit 5), otherwise only the leftmost page would be displayed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H05</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="8" >
-            <widget class="InteractiveButton" name="pushButton_26_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="8">
+            <widget class="InteractiveButton" name="pushButton_26_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">The screen is shifted &lt;span style=" font-weight:600;">TO THE LEFT&lt;/span> as specified in &lt;span style=" font-weight:600;">8-dot units&lt;/span> (16-dot units in Screen 6-7).&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">When SP2=0: Scrolling is done within one page and the non-displayed left side of the page is &lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">displayed on the right hand side of the screen (HO8 is ignored in this mode).&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">When SP2=1: Scrolling is done within 2 pages, and when scrolled, the second page appears to&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">the right habd side of the first page, and when scrolled more, the first page reappears to the right&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">of the second page.&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-weight:600; font-style:italic;">Note&lt;/span>&lt;span style=" font-style:italic;">: When SP2=1, the A15 bit of the Pattern Name table base address register should be set&lt;/span>&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-style:italic;">to "1" (VDP Reg 2, Bit 5), otherwise only the leftmost page would be displayed.&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The screen is shifted &lt;span style=&quot; font-weight:600;&quot;&gt;TO THE LEFT&lt;/span&gt; as specified in &lt;span style=&quot; font-weight:600;&quot;&gt;8-dot units&lt;/span&gt; (16-dot units in Screen 6-7).&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When SP2=0: Scrolling is done within one page and the non-displayed left side of the page is &lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;displayed on the right hand side of the screen (HO8 is ignored in this mode).&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When SP2=1: Scrolling is done within 2 pages, and when scrolled, the second page appears to&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;the right habd side of the first page, and when scrolled more, the first page reappears to the right&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;of the second page.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Note&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;: When SP2=1, the A15 bit of the Pattern Name table base address register should be set&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-style:italic;&quot;&gt;to &quot;1&quot; (VDP Reg 2, Bit 5), otherwise only the leftmost page would be displayed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H04</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="9" >
-            <widget class="InteractiveButton" name="pushButton_26_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="9">
+            <widget class="InteractiveButton" name="pushButton_26_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">The screen is shifted &lt;span style=" font-weight:600;">TO THE LEFT&lt;/span> as specified in &lt;span style=" font-weight:600;">8-dot units&lt;/span> (16-dot units in Screen 6-7).&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">When SP2=0: Scrolling is done within one page and the non-displayed left side of the page is &lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">displayed on the right hand side of the screen (HO8 is ignored in this mode).&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">When SP2=1: Scrolling is done within 2 pages, and when scrolled, the second page appears to&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">the right habd side of the first page, and when scrolled more, the first page reappears to the right&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">of the second page.&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-weight:600; font-style:italic;">Note&lt;/span>&lt;span style=" font-style:italic;">: When SP2=1, the A15 bit of the Pattern Name table base address register should be set&lt;/span>&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-style:italic;">to "1" (VDP Reg 2, Bit 5), otherwise only the leftmost page would be displayed.&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The screen is shifted &lt;span style=&quot; font-weight:600;&quot;&gt;TO THE LEFT&lt;/span&gt; as specified in &lt;span style=&quot; font-weight:600;&quot;&gt;8-dot units&lt;/span&gt; (16-dot units in Screen 6-7).&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When SP2=0: Scrolling is done within one page and the non-displayed left side of the page is &lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;displayed on the right hand side of the screen (HO8 is ignored in this mode).&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When SP2=1: Scrolling is done within 2 pages, and when scrolled, the second page appears to&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;the right habd side of the first page, and when scrolled more, the first page reappears to the right&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;of the second page.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Note&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;: When SP2=1, the A15 bit of the Pattern Name table base address register should be set&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-style:italic;&quot;&gt;to &quot;1&quot; (VDP Reg 2, Bit 5), otherwise only the leftmost page would be displayed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H03</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="0" >
-            <widget class="QLabel" name="label_R27" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_R27">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#27</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="2" column="1" >
-            <widget class="QLabel" name="label_val_27" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="1">
+            <widget class="QLabel" name="label_val_27">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 27</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="2" column="2" >
-            <widget class="InteractiveButton" name="pushButton_27_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="2">
+            <widget class="InteractiveButton" name="pushButton_27_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="3" >
-            <widget class="InteractiveButton" name="pushButton_27_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="3">
+            <widget class="InteractiveButton" name="pushButton_27_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="4" >
-            <widget class="InteractiveButton" name="pushButton_27_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="4">
+            <widget class="InteractiveButton" name="pushButton_27_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="5" >
-            <widget class="InteractiveButton" name="pushButton_27_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="5">
+            <widget class="InteractiveButton" name="pushButton_27_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="6" >
-            <widget class="InteractiveButton" name="pushButton_27_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="6">
+            <widget class="InteractiveButton" name="pushButton_27_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="7" >
-            <widget class="InteractiveButton" name="pushButton_27_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="7">
+            <widget class="InteractiveButton" name="pushButton_27_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">The screen is shifted &lt;span style=" font-weight:600;">TO THE RIGHT&lt;/span> (unlike as for Register 26 which shifts to the left) as specified in&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-weight:600;">1-dot units&lt;/span> (2-dot units in Screen 6-7). When this register is set to a non-zero value, the colors of the&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">leftmost pixel(s) will be undefined, to avoid this dirt effect, the MSK bit must be set, the leftmost 8&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">pixels (16 pixels in Screen 6-7) will be then covered by the border color.&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The screen is shifted &lt;span style=&quot; font-weight:600;&quot;&gt;TO THE RIGHT&lt;/span&gt; (unlike as for Register 26 which shifts to the left) as specified in&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;1-dot units&lt;/span&gt; (2-dot units in Screen 6-7). When this register is set to a non-zero value, the colors of the&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;leftmost pixel(s) will be undefined, to avoid this dirt effect, the MSK bit must be set, the leftmost 8&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;pixels (16 pixels in Screen 6-7) will be then covered by the border color.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H02</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="8" >
-            <widget class="InteractiveButton" name="pushButton_27_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="8">
+            <widget class="InteractiveButton" name="pushButton_27_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">The screen is shifted &lt;span style=" font-weight:600;">TO THE RIGHT&lt;/span> (unlike as for Register 26 which shifts to the left) as specified in&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-weight:600;">1-dot units&lt;/span> (2-dot units in Screen 6-7). When this register is set to a non-zero value, the colors of the&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">leftmost pixel(s) will be undefined, to avoid this dirt effect, the MSK bit must be set, the leftmost 8&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">pixels (16 pixels in Screen 6-7) will be then covered by the border color.&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The screen is shifted &lt;span style=&quot; font-weight:600;&quot;&gt;TO THE RIGHT&lt;/span&gt; (unlike as for Register 26 which shifts to the left) as specified in&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;1-dot units&lt;/span&gt; (2-dot units in Screen 6-7). When this register is set to a non-zero value, the colors of the&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;leftmost pixel(s) will be undefined, to avoid this dirt effect, the MSK bit must be set, the leftmost 8&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;pixels (16 pixels in Screen 6-7) will be then covered by the border color.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H01</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="9" >
-            <widget class="InteractiveButton" name="pushButton_27_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="9">
+            <widget class="InteractiveButton" name="pushButton_27_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
-              <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+             <property name="toolTip">
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">The screen is shifted &lt;span style=" font-weight:600;">TO THE RIGHT&lt;/span> (unlike as for Register 26 which shifts to the left) as specified in&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-weight:600;">1-dot units&lt;/span> (2-dot units in Screen 6-7). When this register is set to a non-zero value, the colors of the&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">leftmost pixel(s) will be undefined, to avoid this dirt effect, the MSK bit must be set, the leftmost 8&lt;/p>
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">pixels (16 pixels in Screen 6-7) will be then covered by the border color.&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The screen is shifted &lt;span style=&quot; font-weight:600;&quot;&gt;TO THE RIGHT&lt;/span&gt; (unlike as for Register 26 which shifts to the left) as specified in&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;1-dot units&lt;/span&gt; (2-dot units in Screen 6-7). When this register is set to a non-zero value, the colors of the&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;leftmost pixel(s) will be undefined, to avoid this dirt effect, the MSK bit must be set, the leftmost 8&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;pixels (16 pixels in Screen 6-7) will be then covered by the border color.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H00</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
@@ -2769,11 +2788,11 @@ p, li { white-space: pre-wrap; }
          </widget>
         </item>
         <item>
-         <spacer name="verticalSpacer_4" >
-          <property name="orientation" >
+         <spacer name="verticalSpacer_4">
+          <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
-          <property name="sizeHint" stdset="0" >
+          <property name="sizeHint" stdset="0">
            <size>
             <width>20</width>
             <height>4</height>
@@ -2782,2553 +2801,2562 @@ p, li { white-space: pre-wrap; }
          </spacer>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox_TableBase" >
-          <property name="title" >
+         <widget class="QGroupBox" name="groupBox_TableBase">
+          <property name="title">
            <string>Table Base Address Registers</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_5" >
-           <property name="horizontalSpacing" >
-            <number>1</number>
-           </property>
-           <property name="verticalSpacing" >
-            <number>3</number>
-           </property>
-           <property name="margin" >
+          <layout class="QGridLayout" name="gridLayout_5">
+           <property name="leftMargin">
             <number>0</number>
            </property>
-           <item row="0" column="0" >
-            <widget class="QLabel" name="label_R2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="horizontalSpacing">
+            <number>1</number>
+           </property>
+           <property name="verticalSpacing">
+            <number>3</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_R2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#2</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="0" column="1" >
-            <widget class="QLabel" name="label_val_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_val_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 2</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="0" column="2" >
-            <widget class="InteractiveButton" name="pushButton_2_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="2">
+            <widget class="InteractiveButton" name="pushButton_2_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern name table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
-             <property name="flat" >
+             <property name="flat">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="3" >
-            <widget class="InteractiveButton" name="pushButton_2_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="3">
+            <widget class="InteractiveButton" name="pushButton_2_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern name table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A16</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="4" >
-            <widget class="InteractiveButton" name="pushButton_2_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="4">
+            <widget class="InteractiveButton" name="pushButton_2_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern name table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A15</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="5" >
-            <widget class="InteractiveButton" name="pushButton_2_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="5">
+            <widget class="InteractiveButton" name="pushButton_2_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern name table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A14</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="6" >
-            <widget class="InteractiveButton" name="pushButton_2_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="6">
+            <widget class="InteractiveButton" name="pushButton_2_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern name table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A13</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="7" >
-            <widget class="InteractiveButton" name="pushButton_2_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="7">
+            <widget class="InteractiveButton" name="pushButton_2_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern name table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A12</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="8" >
-            <widget class="InteractiveButton" name="pushButton_2_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="8">
+            <widget class="InteractiveButton" name="pushButton_2_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern name table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A11</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="9" >
-            <widget class="InteractiveButton" name="pushButton_2_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="9">
+            <widget class="InteractiveButton" name="pushButton_2_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern name table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A10</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="0" >
-            <widget class="QLabel" name="label_R3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_R3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#3</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="1" column="1" >
-            <widget class="QLabel" name="label_val_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="1">
+            <widget class="QLabel" name="label_val_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 3</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="1" column="2" >
-            <widget class="InteractiveButton" name="pushButton_3_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="2">
+            <widget class="InteractiveButton" name="pushButton_3_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A13</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="3" >
-            <widget class="InteractiveButton" name="pushButton_3_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="3">
+            <widget class="InteractiveButton" name="pushButton_3_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A12</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="4" >
-            <widget class="InteractiveButton" name="pushButton_3_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="4">
+            <widget class="InteractiveButton" name="pushButton_3_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A11</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="5" >
-            <widget class="InteractiveButton" name="pushButton_3_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="5">
+            <widget class="InteractiveButton" name="pushButton_3_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A10</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="6" >
-            <widget class="InteractiveButton" name="pushButton_3_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="6">
+            <widget class="InteractiveButton" name="pushButton_3_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A9</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="7" >
-            <widget class="InteractiveButton" name="pushButton_3_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="7">
+            <widget class="InteractiveButton" name="pushButton_3_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A8</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="8" >
-            <widget class="InteractiveButton" name="pushButton_3_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="8">
+            <widget class="InteractiveButton" name="pushButton_3_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A7</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="9" >
-            <widget class="InteractiveButton" name="pushButton_3_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="9">
+            <widget class="InteractiveButton" name="pushButton_3_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A6</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="0" >
-            <widget class="QLabel" name="label_R10" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_R10">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#10</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="2" column="1" >
-            <widget class="QLabel" name="label_val_10" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="1">
+            <widget class="QLabel" name="label_val_10">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 10</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="2" column="2" >
-            <widget class="InteractiveButton" name="pushButton_10_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="2">
+            <widget class="InteractiveButton" name="pushButton_10_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="3" >
-            <widget class="InteractiveButton" name="pushButton_10_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="3">
+            <widget class="InteractiveButton" name="pushButton_10_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="4" >
-            <widget class="InteractiveButton" name="pushButton_10_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="4">
+            <widget class="InteractiveButton" name="pushButton_10_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="5" >
-            <widget class="InteractiveButton" name="pushButton_10_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="5">
+            <widget class="InteractiveButton" name="pushButton_10_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="6" >
-            <widget class="InteractiveButton" name="pushButton_10_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="6">
+            <widget class="InteractiveButton" name="pushButton_10_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="7" >
-            <widget class="InteractiveButton" name="pushButton_10_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="7">
+            <widget class="InteractiveButton" name="pushButton_10_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A16</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="8" >
-            <widget class="InteractiveButton" name="pushButton_10_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="8">
+            <widget class="InteractiveButton" name="pushButton_10_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A15</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="9" >
-            <widget class="InteractiveButton" name="pushButton_10_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="9">
+            <widget class="InteractiveButton" name="pushButton_10_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A14</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="0" >
-            <widget class="QLabel" name="label_R4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_R4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#4</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="3" column="1" >
-            <widget class="QLabel" name="label_val_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="1">
+            <widget class="QLabel" name="label_val_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 4</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="3" column="2" >
-            <widget class="InteractiveButton" name="pushButton_4_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="2">
+            <widget class="InteractiveButton" name="pushButton_4_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="3" >
-            <widget class="InteractiveButton" name="pushButton_4_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="3">
+            <widget class="InteractiveButton" name="pushButton_4_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="4" >
-            <widget class="InteractiveButton" name="pushButton_4_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="4">
+            <widget class="InteractiveButton" name="pushButton_4_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A16</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="5" >
-            <widget class="InteractiveButton" name="pushButton_4_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="5">
+            <widget class="InteractiveButton" name="pushButton_4_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A15</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="6" >
-            <widget class="InteractiveButton" name="pushButton_4_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="6">
+            <widget class="InteractiveButton" name="pushButton_4_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A14</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="7" >
-            <widget class="InteractiveButton" name="pushButton_4_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="7">
+            <widget class="InteractiveButton" name="pushButton_4_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A13</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="8" >
-            <widget class="InteractiveButton" name="pushButton_4_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="8">
+            <widget class="InteractiveButton" name="pushButton_4_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A12</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="9" >
-            <widget class="InteractiveButton" name="pushButton_4_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="9">
+            <widget class="InteractiveButton" name="pushButton_4_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A11</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="0" >
-            <widget class="QLabel" name="label_R5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_R5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#5</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="4" column="1" >
-            <widget class="QLabel" name="label_val_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="1">
+            <widget class="QLabel" name="label_val_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 5</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="4" column="2" >
-            <widget class="InteractiveButton" name="pushButton_5_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="2">
+            <widget class="InteractiveButton" name="pushButton_5_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A14</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="3" >
-            <widget class="InteractiveButton" name="pushButton_5_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="3">
+            <widget class="InteractiveButton" name="pushButton_5_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A13</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="4" >
-            <widget class="InteractiveButton" name="pushButton_5_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="4">
+            <widget class="InteractiveButton" name="pushButton_5_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A12</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="5" >
-            <widget class="InteractiveButton" name="pushButton_5_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="5">
+            <widget class="InteractiveButton" name="pushButton_5_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A11</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="6" >
-            <widget class="InteractiveButton" name="pushButton_5_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="6">
+            <widget class="InteractiveButton" name="pushButton_5_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A10</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="7" >
-            <widget class="InteractiveButton" name="pushButton_5_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="7">
+            <widget class="InteractiveButton" name="pushButton_5_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A9</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="8" >
-            <widget class="InteractiveButton" name="pushButton_5_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="8">
+            <widget class="InteractiveButton" name="pushButton_5_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A8</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="9" >
-            <widget class="InteractiveButton" name="pushButton_5_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="9">
+            <widget class="InteractiveButton" name="pushButton_5_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register low</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A7</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="0" >
-            <widget class="QLabel" name="label_R11" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_R11">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#11</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="5" column="1" >
-            <widget class="QLabel" name="label_val_11" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="1">
+            <widget class="QLabel" name="label_val_11">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 11</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="5" column="2" >
-            <widget class="InteractiveButton" name="pushButton_11_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="2">
+            <widget class="InteractiveButton" name="pushButton_11_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="3" >
-            <widget class="InteractiveButton" name="pushButton_11_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="3">
+            <widget class="InteractiveButton" name="pushButton_11_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="4" >
-            <widget class="InteractiveButton" name="pushButton_11_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="4">
+            <widget class="InteractiveButton" name="pushButton_11_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="5" >
-            <widget class="InteractiveButton" name="pushButton_11_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="5">
+            <widget class="InteractiveButton" name="pushButton_11_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="6" >
-            <widget class="InteractiveButton" name="pushButton_11_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="6">
+            <widget class="InteractiveButton" name="pushButton_11_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="7" >
-            <widget class="InteractiveButton" name="pushButton_11_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="7">
+            <widget class="InteractiveButton" name="pushButton_11_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="8" >
-            <widget class="InteractiveButton" name="pushButton_11_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="8">
+            <widget class="InteractiveButton" name="pushButton_11_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A16</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="9" >
-            <widget class="InteractiveButton" name="pushButton_11_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="9">
+            <widget class="InteractiveButton" name="pushButton_11_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite attribute table base address register high</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A15</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="6" column="0" >
-            <widget class="QLabel" name="label_R6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="6" column="0">
+            <widget class="QLabel" name="label_R6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#6</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="6" column="1" >
-            <widget class="QLabel" name="label_val_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="6" column="1">
+            <widget class="QLabel" name="label_val_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 6</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="6" column="2" >
-            <widget class="InteractiveButton" name="pushButton_6_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="6" column="2">
+            <widget class="InteractiveButton" name="pushButton_6_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="6" column="3" >
-            <widget class="InteractiveButton" name="pushButton_6_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="6" column="3">
+            <widget class="InteractiveButton" name="pushButton_6_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="6" column="4" >
-            <widget class="InteractiveButton" name="pushButton_6_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="6" column="4">
+            <widget class="InteractiveButton" name="pushButton_6_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A16</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="6" column="5" >
-            <widget class="InteractiveButton" name="pushButton_6_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="6" column="5">
+            <widget class="InteractiveButton" name="pushButton_6_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A15</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="6" column="6" >
-            <widget class="InteractiveButton" name="pushButton_6_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="6" column="6">
+            <widget class="InteractiveButton" name="pushButton_6_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A14</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="6" column="7" >
-            <widget class="InteractiveButton" name="pushButton_6_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="6" column="7">
+            <widget class="InteractiveButton" name="pushButton_6_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A13</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="6" column="8" >
-            <widget class="InteractiveButton" name="pushButton_6_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="6" column="8">
+            <widget class="InteractiveButton" name="pushButton_6_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A12</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="6" column="9" >
-            <widget class="InteractiveButton" name="pushButton_6_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="6" column="9">
+            <widget class="InteractiveButton" name="pushButton_6_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Sprite pattern generator table base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A11</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
@@ -5339,11 +5367,11 @@ p, li { white-space: pre-wrap; }
        </layout>
       </item>
       <item>
-       <spacer name="horizontalSpacer_2" >
-        <property name="orientation" >
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <property name="sizeHint" stdset="0" >
+        <property name="sizeHint" stdset="0">
          <size>
           <width>10</width>
           <height>10</height>
@@ -5352,2199 +5380,2199 @@ p, li { white-space: pre-wrap; }
        </spacer>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_5" >
-        <property name="spacing" >
+       <layout class="QVBoxLayout" name="verticalLayout_5">
+        <property name="spacing">
          <number>9</number>
         </property>
         <item>
-         <widget class="QGroupBox" name="groupBox_Color" >
-          <property name="title" >
+         <widget class="QGroupBox" name="groupBox_Color">
+          <property name="title">
            <string>Color Registers</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_2" >
-           <property name="sizeConstraint" >
+          <layout class="QGridLayout" name="gridLayout_2">
+           <property name="sizeConstraint">
             <enum>QLayout::SetMinimumSize</enum>
            </property>
-           <property name="leftMargin" >
+           <property name="leftMargin">
             <number>0</number>
            </property>
-           <property name="topMargin" >
+           <property name="topMargin">
             <number>0</number>
            </property>
-           <property name="horizontalSpacing" >
+           <property name="horizontalSpacing">
             <number>1</number>
            </property>
-           <property name="verticalSpacing" >
+           <property name="verticalSpacing">
             <number>3</number>
            </property>
-           <item row="0" column="0" >
-            <widget class="QLabel" name="label_R7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_R7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>60</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#7</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="0" column="1" >
-            <widget class="QLabel" name="label_val_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_val_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>40</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 7</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="0" column="2" >
-            <widget class="InteractiveButton" name="pushButton_7_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="2">
+            <widget class="InteractiveButton" name="pushButton_7_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back drop color register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>TC3</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="3" >
-            <widget class="InteractiveButton" name="pushButton_7_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="3">
+            <widget class="InteractiveButton" name="pushButton_7_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back drop color register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>TC2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="4" >
-            <widget class="InteractiveButton" name="pushButton_7_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="4">
+            <widget class="InteractiveButton" name="pushButton_7_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back drop color register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>TC1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="5" >
-            <widget class="InteractiveButton" name="pushButton_7_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="5">
+            <widget class="InteractiveButton" name="pushButton_7_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back drop color register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>TC0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="6" >
-            <widget class="InteractiveButton" name="pushButton_7_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="6">
+            <widget class="InteractiveButton" name="pushButton_7_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back drop color register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>BD3</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="7" >
-            <widget class="InteractiveButton" name="pushButton_7_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="7">
+            <widget class="InteractiveButton" name="pushButton_7_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back drop color register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>BD2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="8" >
-            <widget class="InteractiveButton" name="pushButton_7_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="8">
+            <widget class="InteractiveButton" name="pushButton_7_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back drop color register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>BD1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="9" >
-            <widget class="InteractiveButton" name="pushButton_7_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="9">
+            <widget class="InteractiveButton" name="pushButton_7_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back drop color register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>BD0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="0" >
-            <widget class="QLabel" name="label_R12" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_R12">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>60</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#12</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="1" column="1" >
-            <widget class="QLabel" name="label_val_12" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="1">
+            <widget class="QLabel" name="label_val_12">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>40</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 12</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="1" column="2" >
-            <widget class="InteractiveButton" name="pushButton_12_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="2">
+            <widget class="InteractiveButton" name="pushButton_12_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back color register\nUsed for blinking in TEXT 2 mode.</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>T23</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="3" >
-            <widget class="InteractiveButton" name="pushButton_12_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="3">
+            <widget class="InteractiveButton" name="pushButton_12_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back color register\nUsed for blinking in TEXT 2 mode.</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>T22</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="4" >
-            <widget class="InteractiveButton" name="pushButton_12_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="4">
+            <widget class="InteractiveButton" name="pushButton_12_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back color register\nUsed for blinking in TEXT 2 mode.</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>T21</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="5" >
-            <widget class="InteractiveButton" name="pushButton_12_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="5">
+            <widget class="InteractiveButton" name="pushButton_12_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back color register\nUsed for blinking in TEXT 2 mode.</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>T20</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="6" >
-            <widget class="InteractiveButton" name="pushButton_12_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="6">
+            <widget class="InteractiveButton" name="pushButton_12_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back color register\nUsed for blinking in TEXT 2 mode.</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>BC3</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="7" >
-            <widget class="InteractiveButton" name="pushButton_12_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="7">
+            <widget class="InteractiveButton" name="pushButton_12_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back color register\nUsed for blinking in TEXT 2 mode.</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>BC2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="8" >
-            <widget class="InteractiveButton" name="pushButton_12_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="8">
+            <widget class="InteractiveButton" name="pushButton_12_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back color register\nUsed for blinking in TEXT 2 mode.</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>BC1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="9" >
-            <widget class="InteractiveButton" name="pushButton_12_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="9">
+            <widget class="InteractiveButton" name="pushButton_12_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Text color/Back color register\nUsed for blinking in TEXT 2 mode.</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>BC0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="0" >
-            <widget class="QLabel" name="label_R13" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_R13">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>60</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#13</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="2" column="1" >
-            <widget class="QLabel" name="label_val_13" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="1">
+            <widget class="QLabel" name="label_val_13">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>40</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 13</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="2" column="2" >
-            <widget class="InteractiveButton" name="pushButton_13_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="2">
+            <widget class="InteractiveButton" name="pushButton_13_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Blinking period register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>ON3</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="3" >
-            <widget class="InteractiveButton" name="pushButton_13_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="3">
+            <widget class="InteractiveButton" name="pushButton_13_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Blinking period register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>ON2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="4" >
-            <widget class="InteractiveButton" name="pushButton_13_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="4">
+            <widget class="InteractiveButton" name="pushButton_13_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Blinking period register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>ON1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="5" >
-            <widget class="InteractiveButton" name="pushButton_13_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="5">
+            <widget class="InteractiveButton" name="pushButton_13_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Blinking period register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>ON0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="6" >
-            <widget class="InteractiveButton" name="pushButton_13_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="6">
+            <widget class="InteractiveButton" name="pushButton_13_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Blinking period register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>OF3</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="7" >
-            <widget class="InteractiveButton" name="pushButton_13_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="7">
+            <widget class="InteractiveButton" name="pushButton_13_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Blinking period register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>OF2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="8" >
-            <widget class="InteractiveButton" name="pushButton_13_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="8">
+            <widget class="InteractiveButton" name="pushButton_13_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Blinking period register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>OF1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="9" >
-            <widget class="InteractiveButton" name="pushButton_13_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="9">
+            <widget class="InteractiveButton" name="pushButton_13_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Blinking period register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>OF0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="0" >
-            <widget class="QLabel" name="label_R20" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_R20">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>60</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#20</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="3" column="1" >
-            <widget class="QLabel" name="label_val_20" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="1">
+            <widget class="QLabel" name="label_val_20">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>40</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 20</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="3" column="2" >
-            <widget class="InteractiveButton" name="pushButton_20_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="2">
+            <widget class="InteractiveButton" name="pushButton_20_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 1</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="3" >
-            <widget class="InteractiveButton" name="pushButton_20_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="3">
+            <widget class="InteractiveButton" name="pushButton_20_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 1</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="4" >
-            <widget class="InteractiveButton" name="pushButton_20_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="4">
+            <widget class="InteractiveButton" name="pushButton_20_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 1</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="5" >
-            <widget class="InteractiveButton" name="pushButton_20_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="5">
+            <widget class="InteractiveButton" name="pushButton_20_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 1</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="6" >
-            <widget class="InteractiveButton" name="pushButton_20_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="6">
+            <widget class="InteractiveButton" name="pushButton_20_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 1</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="7" >
-            <widget class="InteractiveButton" name="pushButton_20_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="7">
+            <widget class="InteractiveButton" name="pushButton_20_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 1</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="8" >
-            <widget class="InteractiveButton" name="pushButton_20_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="8">
+            <widget class="InteractiveButton" name="pushButton_20_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 1</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="9" >
-            <widget class="InteractiveButton" name="pushButton_20_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="9">
+            <widget class="InteractiveButton" name="pushButton_20_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 1</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="0" >
-            <widget class="QLabel" name="label_R21" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_R21">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>60</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#21</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="4" column="1" >
-            <widget class="QLabel" name="label_val_21" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="1">
+            <widget class="QLabel" name="label_val_21">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>40</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 21</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="4" column="2" >
-            <widget class="InteractiveButton" name="pushButton_21_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="2">
+            <widget class="InteractiveButton" name="pushButton_21_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 2</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="3" >
-            <widget class="InteractiveButton" name="pushButton_21_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="3">
+            <widget class="InteractiveButton" name="pushButton_21_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 2</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="4" >
-            <widget class="InteractiveButton" name="pushButton_21_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="4">
+            <widget class="InteractiveButton" name="pushButton_21_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 2</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="5" >
-            <widget class="InteractiveButton" name="pushButton_21_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="5">
+            <widget class="InteractiveButton" name="pushButton_21_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 2</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="6" >
-            <widget class="InteractiveButton" name="pushButton_21_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="6">
+            <widget class="InteractiveButton" name="pushButton_21_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 2</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="7" >
-            <widget class="InteractiveButton" name="pushButton_21_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="7">
+            <widget class="InteractiveButton" name="pushButton_21_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 2</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="8" >
-            <widget class="InteractiveButton" name="pushButton_21_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="8">
+            <widget class="InteractiveButton" name="pushButton_21_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 2</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="9" >
-            <widget class="InteractiveButton" name="pushButton_21_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="4" column="9">
+            <widget class="InteractiveButton" name="pushButton_21_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 2</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="0" >
-            <widget class="QLabel" name="label_R22" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_R22">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>60</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#22</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="5" column="1" >
-            <widget class="QLabel" name="label_val_22" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="1">
+            <widget class="QLabel" name="label_val_22">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>40</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 22</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="5" column="2" >
-            <widget class="InteractiveButton" name="pushButton_22_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="2">
+            <widget class="InteractiveButton" name="pushButton_22_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 3</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="3" >
-            <widget class="InteractiveButton" name="pushButton_22_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="3">
+            <widget class="InteractiveButton" name="pushButton_22_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 3</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="4" >
-            <widget class="InteractiveButton" name="pushButton_22_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="4">
+            <widget class="InteractiveButton" name="pushButton_22_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 3</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="5" >
-            <widget class="InteractiveButton" name="pushButton_22_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="5">
+            <widget class="InteractiveButton" name="pushButton_22_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 3</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="6" >
-            <widget class="InteractiveButton" name="pushButton_22_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="6">
+            <widget class="InteractiveButton" name="pushButton_22_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 3</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="7" >
-            <widget class="InteractiveButton" name="pushButton_22_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="7">
+            <widget class="InteractiveButton" name="pushButton_22_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 3</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="8" >
-            <widget class="InteractiveButton" name="pushButton_22_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="8">
+            <widget class="InteractiveButton" name="pushButton_22_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 3</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="5" column="9" >
-            <widget class="InteractiveButton" name="pushButton_22_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="5" column="9">
+            <widget class="InteractiveButton" name="pushButton_22_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color burst register 3</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
@@ -7553,11 +7581,11 @@ p, li { white-space: pre-wrap; }
          </widget>
         </item>
         <item>
-         <spacer name="verticalSpacer_7" >
-          <property name="orientation" >
+         <spacer name="verticalSpacer_7">
+          <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
-          <property name="sizeHint" stdset="0" >
+          <property name="sizeHint" stdset="0">
            <size>
             <width>20</width>
             <height>4</height>
@@ -7566,1105 +7594,1105 @@ p, li { white-space: pre-wrap; }
          </spacer>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox_Display" >
-          <property name="title" >
+         <widget class="QGroupBox" name="groupBox_Display">
+          <property name="title">
            <string>Display Registers</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_3" >
-           <property name="leftMargin" >
+          <layout class="QGridLayout" name="gridLayout_3">
+           <property name="leftMargin">
             <number>0</number>
            </property>
-           <property name="topMargin" >
+           <property name="topMargin">
             <number>0</number>
            </property>
-           <property name="horizontalSpacing" >
+           <property name="horizontalSpacing">
             <number>1</number>
            </property>
-           <property name="verticalSpacing" >
+           <property name="verticalSpacing">
             <number>3</number>
            </property>
-           <item row="0" column="0" >
-            <widget class="QLabel" name="label_R18" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_R18">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#18</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="0" column="1" >
-            <widget class="QLabel" name="label_val_18" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_val_18">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 18</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="0" column="2" >
-            <widget class="InteractiveButton" name="pushButton_18_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="2">
+            <widget class="InteractiveButton" name="pushButton_18_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display adjust register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>V3</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="3" >
-            <widget class="InteractiveButton" name="pushButton_18_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="3">
+            <widget class="InteractiveButton" name="pushButton_18_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display adjust register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>V2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="4" >
-            <widget class="InteractiveButton" name="pushButton_18_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="4">
+            <widget class="InteractiveButton" name="pushButton_18_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display adjust register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>V1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="5" >
-            <widget class="InteractiveButton" name="pushButton_18_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="5">
+            <widget class="InteractiveButton" name="pushButton_18_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display adjust register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>V0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="6" >
-            <widget class="InteractiveButton" name="pushButton_18_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="6">
+            <widget class="InteractiveButton" name="pushButton_18_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display adjust register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H3</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="7" >
-            <widget class="InteractiveButton" name="pushButton_18_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="7">
+            <widget class="InteractiveButton" name="pushButton_18_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display adjust register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="8" >
-            <widget class="InteractiveButton" name="pushButton_18_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="8">
+            <widget class="InteractiveButton" name="pushButton_18_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display adjust register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="9" >
-            <widget class="InteractiveButton" name="pushButton_18_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="9">
+            <widget class="InteractiveButton" name="pushButton_18_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display adjust register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>H0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="0" >
-            <widget class="QLabel" name="label_R23" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_R23">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#23</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="1" column="1" >
-            <widget class="QLabel" name="label_val_23" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="1">
+            <widget class="QLabel" name="label_val_23">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 23</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="1" column="2" >
-            <widget class="InteractiveButton" name="pushButton_23_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="2">
+            <widget class="InteractiveButton" name="pushButton_23_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display offset register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>DO7</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="3" >
-            <widget class="InteractiveButton" name="pushButton_23_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="3">
+            <widget class="InteractiveButton" name="pushButton_23_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display offset register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>DO6</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="4" >
-            <widget class="InteractiveButton" name="pushButton_23_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="4">
+            <widget class="InteractiveButton" name="pushButton_23_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display offset register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>DO5</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="5" >
-            <widget class="InteractiveButton" name="pushButton_23_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="5">
+            <widget class="InteractiveButton" name="pushButton_23_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display offset register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>DO4</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="6" >
-            <widget class="InteractiveButton" name="pushButton_23_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="6">
+            <widget class="InteractiveButton" name="pushButton_23_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display offset register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>DO3</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="7" >
-            <widget class="InteractiveButton" name="pushButton_23_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="7">
+            <widget class="InteractiveButton" name="pushButton_23_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display offset register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>DO2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="8" >
-            <widget class="InteractiveButton" name="pushButton_23_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="8">
+            <widget class="InteractiveButton" name="pushButton_23_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display offset register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>DO1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="9" >
-            <widget class="InteractiveButton" name="pushButton_23_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="9">
+            <widget class="InteractiveButton" name="pushButton_23_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Display offset register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>DO0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="0" >
-            <widget class="QLabel" name="label_R19" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_R19">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#19</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="2" column="1" >
-            <widget class="QLabel" name="label_val_19" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="1">
+            <widget class="QLabel" name="label_val_19">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 19</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="2" column="2" >
-            <widget class="InteractiveButton" name="pushButton_19_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="2">
+            <widget class="InteractiveButton" name="pushButton_19_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>IL7</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="3" >
-            <widget class="InteractiveButton" name="pushButton_19_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="3">
+            <widget class="InteractiveButton" name="pushButton_19_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>IL6</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="4" >
-            <widget class="InteractiveButton" name="pushButton_19_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="4">
+            <widget class="InteractiveButton" name="pushButton_19_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>IL5</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="5" >
-            <widget class="InteractiveButton" name="pushButton_19_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="5">
+            <widget class="InteractiveButton" name="pushButton_19_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>IL4</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="6" >
-            <widget class="InteractiveButton" name="pushButton_19_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="6">
+            <widget class="InteractiveButton" name="pushButton_19_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>IL3</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="7" >
-            <widget class="InteractiveButton" name="pushButton_19_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="7">
+            <widget class="InteractiveButton" name="pushButton_19_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>IL2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="8" >
-            <widget class="InteractiveButton" name="pushButton_19_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="8">
+            <widget class="InteractiveButton" name="pushButton_19_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>IL1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="9" >
-            <widget class="InteractiveButton" name="pushButton_19_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="9">
+            <widget class="InteractiveButton" name="pushButton_19_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Interrupt line register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>IL0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
@@ -8673,11 +8701,11 @@ p, li { white-space: pre-wrap; }
          </widget>
         </item>
         <item>
-         <spacer name="verticalSpacer_6" >
-          <property name="orientation" >
+         <spacer name="verticalSpacer_6">
+          <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
-          <property name="sizeHint" stdset="0" >
+          <property name="sizeHint" stdset="0">
            <size>
             <width>20</width>
             <height>4</height>
@@ -8686,1467 +8714,1467 @@ p, li { white-space: pre-wrap; }
          </spacer>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox_Access" >
-          <property name="title" >
+         <widget class="QGroupBox" name="groupBox_Access">
+          <property name="title">
            <string>Access Registers</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_4" >
-           <property name="leftMargin" >
+          <layout class="QGridLayout" name="gridLayout_4">
+           <property name="leftMargin">
             <number>0</number>
            </property>
-           <property name="topMargin" >
+           <property name="topMargin">
             <number>0</number>
            </property>
-           <property name="horizontalSpacing" >
+           <property name="horizontalSpacing">
             <number>1</number>
            </property>
-           <property name="verticalSpacing" >
+           <property name="verticalSpacing">
             <number>3</number>
            </property>
-           <item row="0" column="0" >
-            <widget class="QLabel" name="label_R14" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_R14">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#14</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="0" column="1" >
-            <widget class="QLabel" name="label_val_14" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_val_14">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 14</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="0" column="2" >
-            <widget class="InteractiveButton" name="pushButton_14_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="2">
+            <widget class="InteractiveButton" name="pushButton_14_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>VRAM Access base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="3" >
-            <widget class="InteractiveButton" name="pushButton_14_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="3">
+            <widget class="InteractiveButton" name="pushButton_14_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>VRAM Access base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="4" >
-            <widget class="InteractiveButton" name="pushButton_14_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="4">
+            <widget class="InteractiveButton" name="pushButton_14_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>VRAM Access base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="5" >
-            <widget class="InteractiveButton" name="pushButton_14_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="5">
+            <widget class="InteractiveButton" name="pushButton_14_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>VRAM Access base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="6" >
-            <widget class="InteractiveButton" name="pushButton_14_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="6">
+            <widget class="InteractiveButton" name="pushButton_14_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>VRAM Access base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="7" >
-            <widget class="InteractiveButton" name="pushButton_14_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="7">
+            <widget class="InteractiveButton" name="pushButton_14_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>VRAM Access base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A16</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="8" >
-            <widget class="InteractiveButton" name="pushButton_14_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="8">
+            <widget class="InteractiveButton" name="pushButton_14_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>VRAM Access base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A15</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="0" column="9" >
-            <widget class="InteractiveButton" name="pushButton_14_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="0" column="9">
+            <widget class="InteractiveButton" name="pushButton_14_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>VRAM Access base address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>A14</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="0" >
-            <widget class="QLabel" name="label_R15" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_R15">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#15</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="1" column="1" >
-            <widget class="QLabel" name="label_val_15" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="1">
+            <widget class="QLabel" name="label_val_15">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 15</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="1" column="2" >
-            <widget class="InteractiveButton" name="pushButton_15_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="2">
+            <widget class="InteractiveButton" name="pushButton_15_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Status register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="3" >
-            <widget class="InteractiveButton" name="pushButton_15_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="3">
+            <widget class="InteractiveButton" name="pushButton_15_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Status register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="4" >
-            <widget class="InteractiveButton" name="pushButton_15_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="4">
+            <widget class="InteractiveButton" name="pushButton_15_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Status register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="5" >
-            <widget class="InteractiveButton" name="pushButton_15_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="5">
+            <widget class="InteractiveButton" name="pushButton_15_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Status register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="6" >
-            <widget class="InteractiveButton" name="pushButton_15_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="6">
+            <widget class="InteractiveButton" name="pushButton_15_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Status register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>S3</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="7" >
-            <widget class="InteractiveButton" name="pushButton_15_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="7">
+            <widget class="InteractiveButton" name="pushButton_15_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Status register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>S2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="8" >
-            <widget class="InteractiveButton" name="pushButton_15_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="8">
+            <widget class="InteractiveButton" name="pushButton_15_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Status register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>S1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="1" column="9" >
-            <widget class="InteractiveButton" name="pushButton_15_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="1" column="9">
+            <widget class="InteractiveButton" name="pushButton_15_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Status register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>S0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="0" >
-            <widget class="QLabel" name="label_R16" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_R16">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#16</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="2" column="1" >
-            <widget class="QLabel" name="label_val_16" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="1">
+            <widget class="QLabel" name="label_val_16">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 16</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="2" column="2" >
-            <widget class="InteractiveButton" name="pushButton_16_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="2">
+            <widget class="InteractiveButton" name="pushButton_16_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color palette address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="3" >
-            <widget class="InteractiveButton" name="pushButton_16_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="3">
+            <widget class="InteractiveButton" name="pushButton_16_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color palette address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="4" >
-            <widget class="InteractiveButton" name="pushButton_16_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="4">
+            <widget class="InteractiveButton" name="pushButton_16_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color palette address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="5" >
-            <widget class="InteractiveButton" name="pushButton_16_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="5">
+            <widget class="InteractiveButton" name="pushButton_16_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color palette address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="6" >
-            <widget class="InteractiveButton" name="pushButton_16_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="6">
+            <widget class="InteractiveButton" name="pushButton_16_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color palette address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>C3</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="7" >
-            <widget class="InteractiveButton" name="pushButton_16_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="7">
+            <widget class="InteractiveButton" name="pushButton_16_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color palette address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>C2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="8" >
-            <widget class="InteractiveButton" name="pushButton_16_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="8">
+            <widget class="InteractiveButton" name="pushButton_16_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color palette address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>C1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="9" >
-            <widget class="InteractiveButton" name="pushButton_16_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="2" column="9">
+            <widget class="InteractiveButton" name="pushButton_16_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Color palette address register</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>C0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="0" >
-            <widget class="QLabel" name="label_R17" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_R17">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>45</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>R#17</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="3" column="1" >
-            <widget class="QLabel" name="label_val_17" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="1">
+            <widget class="QLabel" name="label_val_17">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>21</horstretch>
                <verstretch>21</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
               <size>
                <width>30</width>
                <height>0</height>
               </size>
              </property>
-             <property name="focusPolicy" >
+             <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Register 17</string>
              </property>
-             <property name="text" >
-              <string comment="testtext" >FF</string>
+             <property name="text">
+              <string comment="testtext">FF</string>
              </property>
-             <property name="alignment" >
+             <property name="alignment">
               <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
-           <item row="3" column="2" >
-            <widget class="InteractiveButton" name="pushButton_17_7" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="2">
+            <widget class="InteractiveButton" name="pushButton_17_7">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Control register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>AII</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="3" >
-            <widget class="InteractiveButton" name="pushButton_17_6" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="3">
+            <widget class="InteractiveButton" name="pushButton_17_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Control register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string> 0 </string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="4" >
-            <widget class="InteractiveButton" name="pushButton_17_5" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="4">
+            <widget class="InteractiveButton" name="pushButton_17_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Control register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>RS5</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="5" >
-            <widget class="InteractiveButton" name="pushButton_17_4" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="5">
+            <widget class="InteractiveButton" name="pushButton_17_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Control register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>RS4</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="6" >
-            <widget class="InteractiveButton" name="pushButton_17_3" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="6">
+            <widget class="InteractiveButton" name="pushButton_17_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Control register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>RS3</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="7" >
-            <widget class="InteractiveButton" name="pushButton_17_2" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="7">
+            <widget class="InteractiveButton" name="pushButton_17_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Control register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>RS2</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="8" >
-            <widget class="InteractiveButton" name="pushButton_17_1" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="8">
+            <widget class="InteractiveButton" name="pushButton_17_1">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Control register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>RS1</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="9" >
-            <widget class="InteractiveButton" name="pushButton_17_0" >
-             <property name="sizePolicy" >
-              <sizepolicy vsizetype="Fixed" hsizetype="Fixed" >
+           <item row="3" column="9">
+            <widget class="InteractiveButton" name="pushButton_17_0">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize" >
+             <property name="minimumSize">
+              <size>
+               <width>45</width>
+               <height>21</height>
+              </size>
+             </property>
+             <property name="maximumSize">
               <size>
                <width>27</width>
                <height>21</height>
               </size>
              </property>
-             <property name="maximumSize" >
-              <size>
-               <width>27</width>
-               <height>21</height>
-              </size>
-             </property>
-             <property name="font" >
+             <property name="font">
               <font>
                <pointsize>8</pointsize>
               </font>
              </property>
-             <property name="toolTip" >
+             <property name="toolTip">
               <string>Control register pointer</string>
              </property>
-             <property name="text" >
+             <property name="text">
               <string>RS0</string>
              </property>
-             <property name="checkable" >
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="checked" >
+             <property name="checked">
               <bool>false</bool>
              </property>
             </widget>
@@ -10157,11 +10185,11 @@ p, li { white-space: pre-wrap; }
        </layout>
       </item>
       <item>
-       <spacer name="horizontalSpacer_3" >
-        <property name="orientation" >
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <property name="sizeHint" stdset="0" >
+        <property name="sizeHint" stdset="0">
          <size>
           <width>10</width>
           <height>10</height>
@@ -10173,26 +10201,26 @@ p, li { white-space: pre-wrap; }
     </widget>
    </item>
    <item>
-    <widget class="Line" name="line" >
-     <property name="lineWidth" >
+    <widget class="Line" name="line">
+     <property name="lineWidth">
       <number>2</number>
      </property>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_4" >
-     <property name="spacing" >
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <property name="spacing">
       <number>9</number>
      </property>
      <item>
-      <spacer name="horizontalSpacer_5" >
-       <property name="orientation" >
+      <spacer name="horizontalSpacer_5">
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint" stdset="0" >
+       <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>
@@ -10201,78 +10229,78 @@ p, li { white-space: pre-wrap; }
       </spacer>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_dec_Mode" >
-       <property name="title" >
+      <widget class="QGroupBox" name="groupBox_dec_Mode">
+       <property name="title">
         <string>Decoding the mode registers</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2" >
-        <property name="spacing" >
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="spacing">
          <number>0</number>
         </property>
-        <property name="leftMargin" >
+        <property name="leftMargin">
          <number>0</number>
         </property>
-        <property name="topMargin" >
+        <property name="topMargin">
          <number>5</number>
         </property>
-        <property name="rightMargin" >
+        <property name="rightMargin">
          <number>0</number>
         </property>
-        <property name="bottomMargin" >
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_m" >
-          <property name="toolTip" >
+         <widget class="InteractiveLabel" name="label_dec_m">
+          <property name="toolTip">
            <string>Screen mode</string>
           </property>
-          <property name="text" >
+          <property name="text">
            <string>Screen</string>
           </property>
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout" >
-          <property name="spacing" >
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="spacing">
            <number>0</number>
           </property>
           <item>
-           <widget class="InteractiveLabel" name="label_dec_nt" >
-            <property name="text" >
+           <widget class="InteractiveLabel" name="label_dec_nt">
+            <property name="text">
              <string>PAL</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_dec_nt2" >
-            <property name="sizePolicy" >
-             <sizepolicy vsizetype="Preferred" hsizetype="Preferred" >
+           <widget class="QLabel" name="label_dec_nt2">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>,</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="InteractiveLabel" name="label_dec_ln" >
-            <property name="text" >
+           <widget class="InteractiveLabel" name="label_dec_ln">
+            <property name="text">
              <string>212</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_dec_ln2" >
-            <property name="text" >
+           <widget class="QLabel" name="label_dec_ln2">
+            <property name="text">
              <string> lines, </string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="InteractiveLabel" name="label_dec_bl" >
-            <property name="text" >
+           <widget class="InteractiveLabel" name="label_dec_bl">
+            <property name="text">
              <string>Display enabeled</string>
             </property>
            </widget>
@@ -10280,17 +10308,17 @@ p, li { white-space: pre-wrap; }
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2" >
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
-           <widget class="InteractiveLabel" name="label_dec_il" >
-            <property name="text" >
+           <widget class="InteractiveLabel" name="label_dec_il">
+            <property name="text">
              <string>interlaced</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="InteractiveLabel" name="label_dec_eo" >
-            <property name="text" >
+           <widget class="InteractiveLabel" name="label_dec_eo">
+            <property name="text">
              <string>alternate pages</string>
             </property>
            </widget>
@@ -10298,45 +10326,45 @@ p, li { white-space: pre-wrap; }
          </layout>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_ie2" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_ie2">
+          <property name="text">
            <string>Interrupt from Horizontal scanning line enabled.</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_ie0" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_ie0">
+          <property name="text">
            <string>Interrupt from Horizontal scanning line enabled.</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_ie1" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_ie1">
+          <property name="text">
            <string>Interrupt from Horizontal scanning line enabled.</string>
           </property>
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3" >
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
-           <widget class="InteractiveLabel" name="label_dec_si" >
-            <property name="text" >
+           <widget class="InteractiveLabel" name="label_dec_si">
+            <property name="text">
              <string>16x16 sprites</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="InteractiveLabel" name="label_dec_mag" >
-            <property name="text" >
+           <widget class="InteractiveLabel" name="label_dec_mag">
+            <property name="text">
              <string>,magnified sprites</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="InteractiveLabel" name="label_dec_spd" >
-            <property name="text" >
+           <widget class="InteractiveLabel" name="label_dec_spd">
+            <property name="text">
              <string>,enabled</string>
             </property>
            </widget>
@@ -10344,22 +10372,22 @@ p, li { white-space: pre-wrap; }
          </layout>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_tp" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_tp">
+          <property name="text">
            <string>Color 0 is transparent</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_dg" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_dg">
+          <property name="text">
            <string>DG explained</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_416K" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_416K">
+          <property name="text">
            <string>Uses 4/16K memory</string>
           </property>
          </widget>
@@ -10368,78 +10396,78 @@ p, li { white-space: pre-wrap; }
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_dec_V9958" >
-       <property name="title" >
+      <widget class="QGroupBox" name="groupBox_dec_V9958">
+       <property name="title">
         <string>Decoding the V9958 registers</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_7" >
-        <property name="spacing" >
+       <layout class="QVBoxLayout" name="verticalLayout_7">
+        <property name="spacing">
          <number>0</number>
         </property>
-        <property name="leftMargin" >
+        <property name="leftMargin">
          <number>0</number>
         </property>
-        <property name="topMargin" >
+        <property name="topMargin">
          <number>5</number>
         </property>
-        <property name="rightMargin" >
+        <property name="rightMargin">
          <number>0</number>
         </property>
-        <property name="bottomMargin" >
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_sp2" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_sp2">
+          <property name="text">
            <string>explaining SP2</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_msk" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_msk">
+          <property name="text">
            <string>explaining  msk</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_wte" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_wte">
+          <property name="text">
            <string>explaining wte</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_yjk" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_yjk">
+          <property name="text">
            <string>explaining yjk</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_yae" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_yae">
+          <property name="text">
            <string>explaining yae</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_vds" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_vds">
+          <property name="text">
            <string>explaining vds</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_cmd" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_cmd">
+          <property name="text">
            <string>explaining cmd</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="InteractiveLabel" name="label_dec_r26" >
-          <property name="text" >
+         <widget class="InteractiveLabel" name="label_dec_r26">
+          <property name="text">
            <string>explaining h0x</string>
           </property>
          </widget>
@@ -10448,121 +10476,121 @@ p, li { white-space: pre-wrap; }
       </widget>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout_3" >
+      <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <widget class="QGroupBox" name="groupBox_dec_TableBase" >
-         <property name="title" >
+        <widget class="QGroupBox" name="groupBox_dec_TableBase">
+         <property name="title">
           <string>Decoding the Table Base Registers</string>
          </property>
-         <layout class="QFormLayout" name="formLayout" >
-          <property name="fieldGrowthPolicy" >
+         <layout class="QFormLayout" name="formLayout">
+          <property name="fieldGrowthPolicy">
            <enum>QFormLayout::ExpandingFieldsGrow</enum>
           </property>
-          <property name="horizontalSpacing" >
+          <property name="horizontalSpacing">
            <number>3</number>
           </property>
-          <property name="verticalSpacing" >
+          <property name="verticalSpacing">
            <number>2</number>
           </property>
-          <property name="leftMargin" >
+          <property name="leftMargin">
            <number>0</number>
           </property>
-          <property name="topMargin" >
+          <property name="topMargin">
            <number>5</number>
           </property>
-          <property name="rightMargin" >
+          <property name="rightMargin">
            <number>0</number>
           </property>
-          <property name="bottomMargin" >
+          <property name="bottomMargin">
            <number>0</number>
           </property>
-          <item row="0" column="0" >
-           <widget class="QLabel" name="label_3" >
-            <property name="text" >
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
              <string>Pattern name table</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_r2" >
-            <property name="minimumSize" >
+          <item row="0" column="1">
+           <widget class="InteractiveLabel" name="label_dec_r2">
+            <property name="minimumSize">
              <size>
               <width>40</width>
               <height>0</height>
              </size>
             </property>
-            <property name="toolTip" >
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>0x0000</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0" >
-           <widget class="QLabel" name="label_4" >
-            <property name="text" >
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
              <string>Color table</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_r3" >
-            <property name="toolTip" >
+          <item row="1" column="1">
+           <widget class="InteractiveLabel" name="label_dec_r3">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>0x0000</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0" >
-           <widget class="QLabel" name="label_6" >
-            <property name="text" >
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
              <string>Pattern generator table</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_r4" >
-            <property name="toolTip" >
+          <item row="2" column="1">
+           <widget class="InteractiveLabel" name="label_dec_r4">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>0x0000</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0" >
-           <widget class="QLabel" name="label_5" >
-            <property name="text" >
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
              <string>Sprite attribute table</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_r5" >
-            <property name="toolTip" >
+          <item row="3" column="1">
+           <widget class="InteractiveLabel" name="label_dec_r5">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>0x0000</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0" >
-           <widget class="QLabel" name="label_7" >
-            <property name="text" >
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
              <string>Sprite pattern generator table</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_r6" >
-            <property name="toolTip" >
+          <item row="4" column="1">
+           <widget class="InteractiveLabel" name="label_dec_r6">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>0x0000</string>
             </property>
            </widget>
@@ -10571,79 +10599,79 @@ p, li { white-space: pre-wrap; }
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_dec_Display" >
-         <property name="title" >
+        <widget class="QGroupBox" name="groupBox_dec_Display">
+         <property name="title">
           <string>Decoding the Display registers</string>
          </property>
-         <layout class="QFormLayout" name="formLayout_2" >
-          <property name="fieldGrowthPolicy" >
+         <layout class="QFormLayout" name="formLayout_2">
+          <property name="fieldGrowthPolicy">
            <enum>QFormLayout::ExpandingFieldsGrow</enum>
           </property>
-          <property name="horizontalSpacing" >
+          <property name="horizontalSpacing">
            <number>3</number>
           </property>
-          <property name="verticalSpacing" >
+          <property name="verticalSpacing">
            <number>2</number>
           </property>
-          <property name="leftMargin" >
+          <property name="leftMargin">
            <number>0</number>
           </property>
-          <property name="topMargin" >
+          <property name="topMargin">
            <number>9</number>
           </property>
-          <property name="rightMargin" >
+          <property name="rightMargin">
            <number>0</number>
           </property>
-          <property name="bottomMargin" >
+          <property name="bottomMargin">
            <number>0</number>
           </property>
-          <item row="0" column="0" >
-           <widget class="QLabel" name="label_9" >
-            <property name="text" >
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
              <string>Display adjust</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_r18" >
-            <property name="toolTip" >
+          <item row="0" column="1">
+           <widget class="InteractiveLabel" name="label_dec_r18">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>(0,0)</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0" >
-           <widget class="QLabel" name="label_10" >
-            <property name="text" >
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
              <string>Display offset</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_r23" >
-            <property name="toolTip" >
+          <item row="1" column="1">
+           <widget class="InteractiveLabel" name="label_dec_r23">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>255</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0" >
-           <widget class="QLabel" name="label_11" >
-            <property name="text" >
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_11">
+            <property name="text">
              <string>Interrupt line</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_r19" >
-            <property name="toolTip" >
+          <item row="2" column="1">
+           <widget class="InteractiveLabel" name="label_dec_r19">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>255</string>
             </property>
            </widget>
@@ -10654,135 +10682,135 @@ p, li { white-space: pre-wrap; }
       </layout>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout" >
+      <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <widget class="QGroupBox" name="groupBox_dec_Color" >
-         <property name="title" >
+        <widget class="QGroupBox" name="groupBox_dec_Color">
+         <property name="title">
           <string>Color Registers</string>
          </property>
-         <layout class="QFormLayout" name="formLayout_3" >
-          <property name="horizontalSpacing" >
+         <layout class="QFormLayout" name="formLayout_3">
+          <property name="horizontalSpacing">
            <number>3</number>
           </property>
-          <property name="verticalSpacing" >
+          <property name="verticalSpacing">
            <number>2</number>
           </property>
-          <property name="leftMargin" >
+          <property name="leftMargin">
            <number>0</number>
           </property>
-          <property name="topMargin" >
+          <property name="topMargin">
            <number>5</number>
           </property>
-          <property name="rightMargin" >
+          <property name="rightMargin">
            <number>5</number>
           </property>
-          <property name="bottomMargin" >
+          <property name="bottomMargin">
            <number>0</number>
           </property>
-          <item row="0" column="0" >
-           <widget class="QLabel" name="label_17" >
-            <property name="text" >
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_17">
+            <property name="text">
              <string>Text color</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_tc" >
-            <property name="minimumSize" >
+          <item row="0" column="1">
+           <widget class="InteractiveLabel" name="label_dec_tc">
+            <property name="minimumSize">
              <size>
               <width>15</width>
               <height>0</height>
              </size>
             </property>
-            <property name="toolTip" >
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>15</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0" >
-           <widget class="QLabel" name="label_bd" >
-            <property name="text" >
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_bd">
+            <property name="text">
              <string>Backdrop color</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_bd" >
-            <property name="toolTip" >
+          <item row="1" column="1">
+           <widget class="InteractiveLabel" name="label_dec_bd">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>15</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0" >
-           <widget class="QLabel" name="label_t2" >
-            <property name="text" >
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_t2">
+            <property name="text">
              <string>Blinking text color</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_t2" >
-            <property name="toolTip" >
+          <item row="2" column="1">
+           <widget class="InteractiveLabel" name="label_dec_t2">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>15</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0" >
-           <widget class="QLabel" name="label_bc" >
-            <property name="text" >
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_bc">
+            <property name="text">
              <string>Blinking backdrop</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_bc" >
-            <property name="toolTip" >
+          <item row="3" column="1">
+           <widget class="InteractiveLabel" name="label_dec_bc">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>15</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0" >
-           <widget class="QLabel" name="label_on" >
-            <property name="text" >
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_on">
+            <property name="text">
              <string>Blinking time on</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_on" >
-            <property name="toolTip" >
+          <item row="4" column="1">
+           <widget class="InteractiveLabel" name="label_dec_on">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>15</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="0" >
-           <widget class="QLabel" name="label_off" >
-            <property name="text" >
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_off">
+            <property name="text">
              <string>Blinking time off</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_off" >
-            <property name="toolTip" >
+          <item row="5" column="1">
+           <widget class="InteractiveLabel" name="label_dec_off">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>15</string>
             </property>
            </widget>
@@ -10791,99 +10819,99 @@ p, li { white-space: pre-wrap; }
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_dec_Access" >
-         <property name="title" >
+        <widget class="QGroupBox" name="groupBox_dec_Access">
+         <property name="title">
           <string>Access registers</string>
          </property>
-         <layout class="QFormLayout" name="formLayout_4" >
-          <property name="horizontalSpacing" >
+         <layout class="QFormLayout" name="formLayout_4">
+          <property name="horizontalSpacing">
            <number>3</number>
           </property>
-          <property name="verticalSpacing" >
+          <property name="verticalSpacing">
            <number>2</number>
           </property>
-          <property name="leftMargin" >
+          <property name="leftMargin">
            <number>0</number>
           </property>
-          <property name="topMargin" >
+          <property name="topMargin">
            <number>5</number>
           </property>
-          <property name="rightMargin" >
+          <property name="rightMargin">
            <number>5</number>
           </property>
-          <property name="bottomMargin" >
+          <property name="bottomMargin">
            <number>0</number>
           </property>
-          <item row="0" column="0" >
-           <widget class="QLabel" name="label_23" >
-            <property name="text" >
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_23">
+            <property name="text">
              <string>Access address</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_r14" >
-            <property name="minimumSize" >
+          <item row="0" column="1">
+           <widget class="InteractiveLabel" name="label_dec_r14">
+            <property name="minimumSize">
              <size>
               <width>22</width>
               <height>0</height>
              </size>
             </property>
-            <property name="toolTip" >
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>255</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0" >
-           <widget class="QLabel" name="label_24" >
-            <property name="text" >
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_24">
+            <property name="text">
              <string>status register</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_r15" >
-            <property name="toolTip" >
+          <item row="1" column="1">
+           <widget class="InteractiveLabel" name="label_dec_r15">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>255</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0" >
-           <widget class="QLabel" name="label_25" >
-            <property name="text" >
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_25">
+            <property name="text">
              <string>color</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_r16" >
-            <property name="toolTip" >
+          <item row="2" column="1">
+           <widget class="InteractiveLabel" name="label_dec_r16">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>255</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0" >
-           <widget class="QLabel" name="label_26" >
-            <property name="text" >
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_26">
+            <property name="text">
              <string>VDP register</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1" >
-           <widget class="InteractiveLabel" name="label_dec_r17" >
-            <property name="toolTip" >
+          <item row="3" column="1">
+           <widget class="InteractiveLabel" name="label_dec_r17">
+            <property name="toolTip">
              <string>Screen mode</string>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>255</string>
             </property>
            </widget>
@@ -10894,11 +10922,11 @@ p, li { white-space: pre-wrap; }
       </layout>
      </item>
      <item>
-      <spacer name="horizontalSpacer_6" >
-       <property name="orientation" >
+      <spacer name="horizontalSpacer_6">
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint" stdset="0" >
+       <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>
@@ -10909,11 +10937,11 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <spacer name="verticalSpacer" >
-     <property name="orientation" >
+    <spacer name="verticalSpacer">
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" stdset="0" >
+     <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
        <height>3</height>
@@ -10922,13 +10950,13 @@ p, li { white-space: pre-wrap; }
     </spacer>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_6" >
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
      <item>
-      <spacer name="horizontalSpacer" >
-       <property name="orientation" >
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint" stdset="0" >
+       <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>
@@ -10937,33 +10965,33 @@ p, li { white-space: pre-wrap; }
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="label" >
-       <property name="text" >
-        <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;">
-&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-size:10pt; font-weight:600; font-style:italic;">Quick hack&lt;/span>&lt;span style=" font-size:10pt; font-style:italic;"> use this to switch between VDP chip, since no autodetection yet in the code&lt;/span>&lt;/p>&lt;/body>&lt;/html></string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600; font-style:italic;&quot;&gt;Quick hack&lt;/span&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt; use this to switch between VDP chip, since no autodetection yet in the code&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
-       <property name="textFormat" >
+       <property name="textFormat">
         <enum>Qt::RichText</enum>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="VDPcomboBox" >
+      <widget class="QComboBox" name="VDPcomboBox">
        <item>
-        <property name="text" >
+        <property name="text">
          <string>V9958</string>
         </property>
        </item>
        <item>
-        <property name="text" >
+        <property name="text">
          <string>V9938</string>
         </property>
        </item>
        <item>
-        <property name="text" >
+        <property name="text">
          <string>TMS99x8</string>
         </property>
        </item>
@@ -10975,14 +11003,14 @@ p, li { white-space: pre-wrap; }
  </widget>
  <customwidgets>
   <customwidget>
-   <class>InteractiveButton</class>
-   <extends>QPushButton</extends>
-   <header>InteractiveButton.h</header>
-  </customwidget>
-  <customwidget>
    <class>InteractiveLabel</class>
    <extends>QLabel</extends>
    <header>InteractiveLabel.h</header>
+  </customwidget>
+  <customwidget>
+   <class>InteractiveButton</class>
+   <extends>QPushButton</extends>
+   <header>InteractiveButton.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
The register labels in the VDPRegistersExplained dialog were unreadable on macOS 10.15. I increased the button sizes in horizontal direction to fix the problem. The fix has been tested on macOS and Linux. Some screenshots have been included for V9958, but the same goes for the dialogs for the V99x8 and V9938.

Before the fix:
<img width="1006" alt="before" src="https://user-images.githubusercontent.com/15607023/138817398-817bff7a-dd5f-4fe4-b98c-19ab0007751d.png">

After the fix (macOS):
<img width="1209" alt="after" src="https://user-images.githubusercontent.com/15607023/138817456-cd60f27a-d806-46a6-87b3-e2ee0d051169.png">

After the fix (Linux):
![after2](https://user-images.githubusercontent.com/15607023/138817494-6884c9ef-6b6c-4573-b294-7dbd201dca0c.png)


