### PR TITLE
update disasm window when break state changes

### DIFF
--- a/src/DebuggerForm.h
+++ b/src/DebuggerForm.h
@@ -96,9 +96,9 @@ private:
 	QAction* viewDebuggableViewerAction;
 
 	QAction* viewBitMappedAction;
-    QAction* viewCharMappedAction;
-    QAction* viewSpritesAction;
-    QAction* viewVDPStatusRegsAction;
+	QAction* viewCharMappedAction;
+	QAction* viewSpritesAction;
+	QAction* viewVDPStatusRegsAction;
 	QAction* viewVDPRegsAction;
 	QAction* viewVDPCommandRegsAction;
 
@@ -158,8 +158,8 @@ private slots:
 	void toggleSlotsDisplay();
 	void toggleMemoryDisplay();
 	void toggleBitMappedDisplay();
-    void toggleCharMappedDisplay();
-    void toggleSpritesDisplay();
+	void toggleCharMappedDisplay();
+	void toggleSpritesDisplay();
 	void toggleVDPRegsDisplay();
 	void toggleVDPStatusRegsDisplay();
 	void toggleVDPCommandRegsDisplay();
@@ -175,7 +175,7 @@ private slots:
 	void breakpointAdd();
 
 	void handleCommandReplyStatus(bool status);
-	
+
 	void toggleView(DockableWidget* widget);
 	void initConnection();
 	void handleUpdate(const QString& type, const QString& name,
@@ -202,7 +202,7 @@ signals:
 	void settingsChanged();
 	void symbolsChanged();
 	void debuggablesChanged(const QMap<QString, int>& list);
-	void emulationChanged();
+	void breakStateEntered();
 };
 
 #endif // DEBUGGERFORM_H

--- a/src/DisasmViewer.cpp
+++ b/src/DisasmViewer.cpp
@@ -76,7 +76,7 @@ DisasmViewer::DisasmViewer(QWidget* parent)
 	scrollBar->setSingleStep(0);
 	scrollBar->setPageStep(0);
 
-	settingsChanged();
+	updateLayout();
 
 	// manual scrollbar handling routines (real size of the data is not known)
 	connect(scrollBar, SIGNAL(actionTriggered(int)),
@@ -104,7 +104,7 @@ void DisasmViewer::resizeEvent(QResizeEvent* e)
 	}
 }
 
-void DisasmViewer::settingsChanged()
+void DisasmViewer::updateLayout()
 {
 	frameL = frameT = frameB = frameWidth();
 	frameR = frameL + scrollBar->sizeHint().width();
@@ -135,7 +135,7 @@ void DisasmViewer::settingsChanged()
 	update();
 }
 
-void DisasmViewer::symbolsChanged()
+void DisasmViewer::refresh()
 {
 	int disasmStart = disasmLines.front().addr;
 	int disasmEnd = disasmLines.back().addr + disasmLines.back().numBytes;

--- a/src/DisasmViewer.h
+++ b/src/DisasmViewer.h
@@ -36,8 +36,8 @@ public slots:
 	void setProgramCounter(quint16 pc);
 	void scrollBarAction(int action);
 	void scrollBarChanged(int value);
-	void settingsChanged();
-	void symbolsChanged();
+	void updateLayout();
+	void refresh();
 
 private:
 	void resizeEvent(QResizeEvent* e) override;

--- a/src/SlotViewer.cpp
+++ b/src/SlotViewer.cpp
@@ -191,6 +191,7 @@ void SlotViewer::refresh()
 void SlotViewer::setMemoryLayout(MemoryLayout* ml)
 {
 	memLayout = ml;
+	update();
 }
 
 void SlotViewer::slotsUpdated(const QString& message)

--- a/src/SlotViewer.h
+++ b/src/SlotViewer.h
@@ -12,11 +12,13 @@ class SlotViewer : public QFrame
 public:
 	SlotViewer(QWidget* parent = nullptr);
 
-	void refresh();
 	void setMemoryLayout(MemoryLayout* ml);
 	void slotsUpdated(const QString& message);
 
 	QSize sizeHint() const override;
+
+public slots:
+	void refresh();
 
 private:
 	void resizeEvent(QResizeEvent* e) override;

--- a/src/VDPDataStore.cpp
+++ b/src/VDPDataStore.cpp
@@ -80,9 +80,12 @@ VDPDataStore& VDPDataStore::instance()
 
 void VDPDataStore::refresh()
 {
-	if (!got_version) return;
-
-	refresh1();
+	if (!got_version) {
+		// No connection? Establish it first.
+		CommClient::instance().sendCommand(new VDPDataStoreVersionCheck(*this));
+	} else {
+		refresh1();
+	}
 }
 
 void VDPDataStore::refresh1()
@@ -99,6 +102,7 @@ void VDPDataStore::refresh2()
 			"[ debug read_block {VDP status regs} 0 16 ]"
 			"[ debug read_block {VDP regs} 0 64 ]"
 			"[ debug read_block {VRAM pointer} 0 2 ]");
+	// receive contents of VRAM
 	new SimpleHexRequest(req, MAX_TOTAL_SIZE - MAX_VRAM_SIZE + vramSize, vram, *this);
 }
 
@@ -106,7 +110,6 @@ void VDPDataStore::DataHexRequestReceived()
 {
 	emit dataRefreshed();
 }
-
 
 const unsigned char* VDPDataStore::getVramPointer() const
 {

--- a/src/VramBitMappedView.cpp
+++ b/src/VramBitMappedView.cpp
@@ -252,6 +252,8 @@ void VramBitMappedView::refresh()
 
 void VramBitMappedView::mouseMoveEvent(QMouseEvent* e)
 {
+	if (!vramBase) return;
+
 	static const unsigned bytes_per_line[] = {
 		0,	//screen 0
 		1,	//screen 1

--- a/src/VramBitMappedView.cpp
+++ b/src/VramBitMappedView.cpp
@@ -47,7 +47,7 @@ void VramBitMappedView::decode()
 
 	printf("\n"
 	       "screenMode: %i\n"
-	       "vram to start decoding: %i\n",
+	       "vram address to start decoding: %i\n",
 	       screenMode, vramAddress);
 	switch (screenMode) {
 	case 12:
@@ -70,7 +70,7 @@ void VramBitMappedView::decode()
 		decodeSCR5();
 		break;
 	}
-	piximage = piximage.fromImage(image);
+	piximage = QPixmap::fromImage(image);
 	update();
 }
 


### PR DESCRIPTION
This should fix issue #21. Not with a refresh button, but actually updating the disasm window after each debug step.