### PR TITLE
using binary search in findBreakpoint() and insertBreakpoint()

### DIFF
--- a/src/DebuggerData.cpp
+++ b/src/DebuggerData.cpp
@@ -271,13 +271,12 @@ bool Breakpoints::inCurrentSlot(const Breakpoint& bp)
 
 void Breakpoints::insertBreakpoint(Breakpoint& bp)
 {
-	for (auto it = breakpoints.begin(); it != breakpoints.end(); ++it) {
-		if (it->address > bp.address) {
-			breakpoints.insert(it, bp);
-			return;
-		}
-	}
-	breakpoints.push_back(bp);
+	auto it = std::upper_bound(breakpoints.begin(), breakpoints.end(), bp,
+	           [](const Breakpoint& bp1, const Breakpoint& bp2) {
+				   return bp1.address < bp2.address;
+			   }
+   			);
+	breakpoints.insert(it, bp);
 }
 
 int Breakpoints::breakpointCount()
@@ -316,9 +315,15 @@ bool Breakpoints::isWatchpoint(quint16 addr, QString *id)
 
 int Breakpoints::findBreakpoint(quint16 addr)
 {
-	// stub
-	// will implement findfirst/findnext scheme for speed
-	return addr;
+    auto i = std::lower_bound(breakpoints.begin(), breakpoints.end(), addr,
+	           [](const Breakpoint& bp, const quint16 addr) {
+				   return bp.address < addr;
+			   }
+   			);
+	if (i != breakpoints.end() && i->address == addr) {
+		return i - breakpoints.begin();
+	}
+	return -1;
 }
 
 int Breakpoints::findNextBreakpoint()

--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -621,7 +621,7 @@ void DebuggerForm::createForm()
 
 	// add widgets
 	for (int i = 0; i < list.size(); ++i) {
-		QStringList s = list.at(i).split(" ", QString::SplitBehavior::SkipEmptyParts);
+		QStringList s = list.at(i).split(" ", Qt::SplitBehaviorFlags::SkipEmptyParts);
 		// get widget
 		if ((dw = dockMan.findDockableWidget(s.at(0)))) {
 			if (s.at(1) == "D") {
@@ -1451,7 +1451,7 @@ void DebuggerForm::setDebuggables(const QString& list)
 	debuggables.clear();
 
 	// process result string
-	QStringList l = list.split(" ", QString::SplitBehavior::SkipEmptyParts);
+	QStringList l = list.split(" ", Qt::SplitBehaviorFlags::SkipEmptyParts);
 	for (int i = 0; i < l.size(); ++i) {
 		QString d = l[i];
 		// combine multiple words

--- a/src/SymbolTable.cpp
+++ b/src/SymbolTable.cpp
@@ -281,7 +281,7 @@ bool SymbolTable::readSymbolFile(
 	QTextStream in(&file);
 	while (!in.atEnd()) {
 		QString line = in.readLine();
-		QStringList l = line.split(equ, QString::SplitBehavior::KeepEmptyParts, Qt::CaseInsensitive);
+		QStringList l = line.split(equ, Qt::SplitBehaviorFlags::KeepEmptyParts, Qt::CaseInsensitive);
 		if (l.size() != 2) continue;
 		int value;
 		if (!parseValue(l.at(1), value)) continue;


### PR DESCRIPTION
binary searching breakpoints is much more efficient, since they are already ordered by address value.