### PR TITLE
Using new 'onDemand' method in DisasmViewer::setAddress by default wh…

### DIFF
--- a/src/DisasmViewer.h
+++ b/src/DisasmViewer.h
@@ -28,7 +28,7 @@ public:
 
 	QSize sizeHint() const override;
 
-	enum {Top, Middle, Bottom, Closest, TopAlways, MiddleAlways, BottomAlways};
+	enum {Top, Middle, Bottom, Closest, TopAlways, MiddleAlways, BottomAlways, OnDemand};
 
 public slots:
 	void setAddress(quint16 addr, int infoLine = FIRST_INFO_LINE, int method = Top);


### PR DESCRIPTION
…en calling DisasmViewer::setProgramCounter. With the 'onDemand' method the disassembled code doesn't move unless needed (only the cursors does).

More info about this, here:
https://www.msx.org/forum/msx-talk/openmsx/propopal-to-change-default-openmsxs-debugger-disasm-scrolling#comment-423909