### PR TITLE
VDPDataStore will ask for VDP data again

### DIFF
--- a/src/VDPDataStore.cpp
+++ b/src/VDPDataStore.cpp
@@ -80,9 +80,12 @@ VDPDataStore& VDPDataStore::instance()
 
 void VDPDataStore::refresh()
 {
-	if (!got_version) return;
-
-	refresh1();
+	if (!got_version) {
+		// No data? Send request again.
+		CommClient::instance().sendCommand(new VDPDataStoreVersionCheck(*this));
+	} else {
+		refresh1();
+	}
 }
 
 void VDPDataStore::refresh1()
@@ -99,6 +102,7 @@ void VDPDataStore::refresh2()
 			"[ debug read_block {VDP status regs} 0 16 ]"
 			"[ debug read_block {VDP regs} 0 64 ]"
 			"[ debug read_block {VRAM pointer} 0 2 ]");
+	// receive contents of VRAM
 	new SimpleHexRequest(req, MAX_TOTAL_SIZE - MAX_VRAM_SIZE + vramSize, vram, *this);
 }
 
@@ -106,7 +110,6 @@ void VDPDataStore::DataHexRequestReceived()
 {
 	emit dataRefreshed();
 }
-
 
 const unsigned char* VDPDataStore::getVramPointer() const
 {

--- a/src/VramBitMappedView.cpp
+++ b/src/VramBitMappedView.cpp
@@ -47,7 +47,7 @@ void VramBitMappedView::decode()
 
 	printf("\n"
 	       "screenMode: %i\n"
-	       "vram to start decoding: %i\n",
+	       "vram address to start decoding: %i\n",
 	       screenMode, vramAddress);
 	switch (screenMode) {
 	case 12:
@@ -70,7 +70,7 @@ void VramBitMappedView::decode()
 		decodeSCR5();
 		break;
 	}
-	piximage = piximage.fromImage(image);
+	piximage = QPixmap::fromImage(image);
 	update();
 }
 
@@ -252,6 +252,8 @@ void VramBitMappedView::refresh()
 
 void VramBitMappedView::mouseMoveEvent(QMouseEvent* e)
 {
+	if (!vramBase) return;
+
 	static const unsigned bytes_per_line[] = {
 		0,	//screen 0
 		1,	//screen 1


### PR DESCRIPTION
Allow `VDPDataStore` to load VRAM data even if connection was established after `TileView` or `BitmapView` dialogs were created.