### PR TITLE
Remove window decorations of floating tools but still allow them to be resized.

### DIFF
--- a/src/DockableWidget.cpp
+++ b/src/DockableWidget.cpp
@@ -9,6 +9,7 @@
 #include <QStyleOptionDockWidget>
 #include <QRubberBand>
 #include <QMouseEvent>
+#include <QStatusBar>
 #include <algorithm>
 
 
@@ -68,6 +69,7 @@ void DockableWidget::setWidget(QWidget* widget)
 {
 	if (mainWidget) {
 		widgetLayout->removeWidget(mainWidget);
+		delete statusBar;
 	}
 	mainWidget = widget;
 
@@ -86,6 +88,12 @@ void DockableWidget::setWidget(QWidget* widget)
 		setMinimumSize(minW, minH);
 		setMaximumSize(maxW, maxH);
 		setSizePolicy(widget->sizePolicy());
+
+		statusBar = new QStatusBar(nullptr);
+		statusBar->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed));
+		statusBar->setVisible(false);
+		statusBar->setSizeGripEnabled(false);
+		widgetLayout->addWidget(statusBar, 2);
 	}
 }
 
@@ -120,7 +128,14 @@ void DockableWidget::setFloating(bool enable, bool showNow)
 	if (floating == enable) return;
 
 	floating = enable;
-	setWindowFlags(floating ? Qt::Tool : Qt::Widget);
+	setWindowFlags(floating ? Qt::FramelessWindowHint | Qt::Tool : Qt::Widget);
+
+	if (mainWidget->sizePolicy().horizontalPolicy() != QSizePolicy::Fixed &&
+			mainWidget->sizePolicy().verticalPolicy() != QSizePolicy::Fixed) {
+		statusBar->setVisible(floating);
+		statusBar->setSizeGripEnabled(floating);
+	}
+
 	if (floating && showNow) {
 		show();
 	}

--- a/src/DockableWidget.h
+++ b/src/DockableWidget.h
@@ -10,6 +10,7 @@ class QHBoxLayout;
 class QVBoxLayout;
 class QRubberBand;
 class DockManager;
+class QStatusBar;
 
 class DockableWidget : public QWidget
 {
@@ -56,6 +57,7 @@ private:
 	QWidget* headerWidget;
 	QLabel* titleLabel;
 	QToolButton* closeButton;
+	QStatusBar* statusBar;
 
 signals:
 	void visibilityChanged(DockableWidget* w);


### PR DESCRIPTION
This patch changes this:
![image](https://user-images.githubusercontent.com/7815819/155214243-b1827f7c-7fbb-40bb-81ed-35687057f9e1.png)

into this:
![image](https://user-images.githubusercontent.com/7815819/155214321-950bb0a2-27d0-4ae3-917e-a11c35d3aab7.png)

When window decoration is active the inexperienced user doesn't know that the tool can be docked back into the dockable area by dragging it over the application window, since that feature only works if you drag the tool by its body (and not by the window decoration). With this patch, the tool can still be resized by the status bar at the bottom right corner. That is, if the tool's QSizePolicy is not (fixed, fixed).

This patch was not tested on windows or mac since I don't use them.