### PR TITLE
fixed some inconsistent name convention according to C++ and Qt rules

### DIFF
--- a/src/BitMapViewer.cpp
+++ b/src/BitMapViewer.cpp
@@ -61,10 +61,10 @@ BitMapViewer::BitMapViewer(QWidget* parent)
 	connect(refreshButton, SIGNAL(clicked(bool)),
 	        &VDPDataStore::instance(), SLOT(refresh()));
 
-	connect(imageWidget, SIGNAL(imagePosition(int,int,int,unsigned,int)),
-	        this, SLOT(imagePositionUpdate(int,int,int,unsigned,int)));
-	connect(imageWidget, SIGNAL(imageClicked (int,int,int,unsigned,int)),
-	        this, SLOT(imagePositionUpdate(int,int,int,unsigned,int)));
+	connect(imageWidget, SIGNAL(imageHovered(int, int, int, unsigned, int)),
+	        this, SLOT(updateImagePosition(int, int, int, unsigned, int)));
+	connect(imageWidget, SIGNAL(imageClicked(int, int, int, unsigned, int)),
+	        this, SLOT(updateImagePosition(int, int, int, unsigned, int)));
 
 	// and now go fetch the initial data
 	VDPDataStore::instance().refresh();
@@ -267,7 +267,7 @@ void BitMapViewer::VDPDataStoreDataRefreshed()
 	decodeVDPregs();
 }
 
-void BitMapViewer::imagePositionUpdate(
+void BitMapViewer::updateImagePosition(
 	int x, int y, int color, unsigned addr, int byteValue)
 {
 	labelX->setText(QString("%1").arg(x, 3, 10, QChar('0')));

--- a/src/BitMapViewer.h
+++ b/src/BitMapViewer.h
@@ -35,7 +35,7 @@ private slots:
 	void on_useVDPPalette_stateChanged(int state);
 	void on_zoomLevel_valueChanged(double d);
 
-	void imagePositionUpdate(int x, int y, int color, unsigned addr, int byteValue);
+	void updateImagePosition(int x, int y, int color, unsigned addr, int byteValue);
 
 	void VDPDataStoreDataRefreshed();
 };

--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -667,7 +667,7 @@ void DebuggerForm::createForm()
 	        flagsView,  SLOT(setFlags(quint8)));
 	connect(regsView,   SIGNAL(spChanged(quint16)),
 	        stackView,  SLOT(setStackPointer(quint16)));
-	connect(disasmView, SIGNAL(toggleBreakpoint(int)),
+	connect(disasmView, SIGNAL(breakpointToggled(int)),
 	                    SLOT(breakpointToggle(int)));
 
 	connect(&comm, SIGNAL(connectionReady()),
@@ -1166,7 +1166,7 @@ void DebuggerForm::handleCommandReplyStatus(bool status)
 	}
 }
 
-void DebuggerForm::breakpointToggle(int addr)
+void DebuggerForm::toggleBreakpoint(int addr)
 {
 	// toggle address unspecified, use cursor address
 	if (addr < 0) addr = disasmView->cursorAddress();
@@ -1186,7 +1186,7 @@ void DebuggerForm::breakpointToggle(int addr)
 	comm.sendCommand(new ListBreakPointsHandler(*this));
 }
 
-void DebuggerForm::breakpointAdd()
+void DebuggerForm::addBreakpoint()
 {
 	BreakpointDialog bpd(memLayout, &session, this);
 	int addr = disasmView->cursorAddress();

--- a/src/DebuggerForm.h
+++ b/src/DebuggerForm.h
@@ -171,11 +171,11 @@ private slots:
 	void executeRunTo();
 	void executeStepOut();
 	void executeStepBack();
-	void breakpointToggle(int addr = -1);
-	void breakpointAdd();
+	void toggleBreakpoint(int addr = -1);
+	void addBreakpoint();
 
 	void handleCommandReplyStatus(bool status);
-	
+
 	void toggleView(DockableWidget* widget);
 	void initConnection();
 	void handleUpdate(const QString& type, const QString& name,

--- a/src/DisasmViewer.cpp
+++ b/src/DisasmViewer.cpp
@@ -716,7 +716,7 @@ void DisasmViewer::mousePressEvent(QMouseEvent* e)
 		} else if (e->x() < frameL + 16) {
 			// clicked on the breakpoint area
 			if (line + disasmTopLine < int(disasmLines.size())) {
-				emit toggleBreakpoint(disasmLines[line + disasmTopLine].addr);
+				emit breakpointToggled(disasmLines[line + disasmTopLine].addr);
 			}
 		}
 	}

--- a/src/DisasmViewer.h
+++ b/src/DisasmViewer.h
@@ -81,7 +81,7 @@ private:
 	int lineAtPos(const QPoint& pos);
 
 signals:
-	void toggleBreakpoint(int addr);
+	void breakpointToggled(int addr);
 };
 
 #endif // DISASMVIEWER_H

--- a/src/TileViewer.cpp
+++ b/src/TileViewer.cpp
@@ -73,14 +73,14 @@ TileViewer::TileViewer(QWidget *parent) : QDialog(parent), image4label(32, 32, Q
     imageWidget->setUseBlink(cb_blinkcolors->isChecked());
     imageWidget->setDrawgrid(cb_drawgrid->isChecked());
 
-    connect(imageWidget,SIGNAL(highlightCount(unsigned char, int )),
-            this,SLOT(highlightInfo(unsigned char , int)));
+    connect(imageWidget, SIGNAL(highlightCount(unsigned char, int)),
+            this, SLOT(highlightInfo(unsigned char, int)));
 
-    connect(imageWidget,SIGNAL(imagePosition(int , int , int )),
-            this,SLOT( imageMouseOver(int , int , int ) )  );
+    connect(imageWidget, SIGNAL(imageHovered(int, int, int)),
+            this, SLOT(imageMouseOver(int, int, int)));
 
-    connect(imageWidget,SIGNAL(imageClicked(int , int , int ,QString)),
-            this,SLOT( characterSelected2Text(int , int , int ,QString) )  );
+    connect(imageWidget, SIGNAL(imageClicked(int, int, int, QString)),
+            this, SLOT(displayCharInfo(int, int, int, QString)));
 
 	// and now go fetch the initial data
 	VDPDataStore::instance().refresh();
@@ -232,7 +232,7 @@ void TileViewer::refresh()
     VDPDataStore::instance().refresh();
 }
 
-void TileViewer::characterSelected2Text(int screenx, int screeny, int character,QString textinfo)
+void TileViewer::displayCharInfo(int screenx, int screeny, int character,QString textinfo)
 {
     label_charpat->setText(QString::number(character));
     plainTextEdit->setPlainText(QString("info for character %1 (%2)\n%3")
@@ -341,8 +341,7 @@ void TileViewer::on_editPaletteButton_clicked(bool /*checked*/)
     PaletteDialog* p=new PaletteDialog();
     p->setPalette(defaultPalette);
     p->setAutoSync(true);
-    connect(p,SIGNAL(paletteSynced()),
-            this,SLOT(paletteChanged()));
+    connect(p, SIGNAL(paletteSynced()), this, SLOT(refresh()));
     p->show();
 //    useVDPPalette->setChecked(false);
 //    QMessageBox::information(
@@ -396,12 +395,6 @@ void TileViewer::on_sp_bordercolor_valueChanged(int i)
 {
     imageWidget->setBorderColor(i);
 }
-
-void TileViewer::paletteChanged()
-{
-    imageWidget->refresh();
-}
-
 
 void TileViewer::on_cb_blinkcolors_stateChanged(int arg1)
 {

--- a/src/TileViewer.h
+++ b/src/TileViewer.h
@@ -4,7 +4,7 @@
 #include "ui_TileViewer.h"
 #include <QDialog>
 
-class VramTiledView; 
+class VramTiledView;
 
 class TileViewer : public QDialog,private Ui::TileViewer
 {
@@ -23,7 +23,7 @@ private:
 private slots:
     void refresh();
 
-    void characterSelected2Text(int screenx, int screeny, int character, QString textinfo);
+    void displayCharInfo(int screenx, int screeny, int character, QString textinfo);
 
     void on_cb_tilemapsource_currentIndexChanged(int index);
     void on_cb_screen_currentIndexChanged(int index);
@@ -44,7 +44,6 @@ private slots:
 
 
 
-    void paletteChanged();
     void VDPDataStoreDataRefreshed();
     void highlightInfo(unsigned char character, int count);
     void imageMouseOver(int screenx, int screeny, int character);

--- a/src/VDPRegViewer.cpp
+++ b/src/VDPRegViewer.cpp
@@ -19,13 +19,13 @@ void buttonHighlightDispatcher::receiveState(bool state)
 {
 	if (state) {
 		if (counter == 0) {
-			emit dispatchState(true);
+			emit stateDispatched(true);
 		}
 		++counter;
 	} else {
 		--counter;
 		if (counter == 0) {
-			emit dispatchState(false);
+			emit stateDispatched(false);
 		}
 	}
 }
@@ -680,7 +680,7 @@ void VDPRegViewer::doConnect(InteractiveButton* but, buttonHighlightDispatcher* 
 {
 	connect(but, SIGNAL(mouseOver(bool)),
 	        dis, SLOT(receiveState(bool)));
-	connect(dis, SIGNAL(dispatchState(bool)),
+	connect(dis, SIGNAL(stateDispatched(bool)),
 	        but, SLOT(highlight(bool)));
 }
 
@@ -712,7 +712,7 @@ buttonHighlightDispatcher* VDPRegViewer::makeGroup(
 	auto* dispat = new buttonHighlightDispatcher();
 	connect(explained, SIGNAL(mouseOver(bool)),
 	        dispat, SLOT(receiveState(bool)));
-	connect(dispat, SIGNAL(dispatchState(bool)),
+	connect(dispat, SIGNAL(stateDispatched(bool)),
 	        explained, SLOT(highlight(bool)));
 	for (auto* item : list) {
 		doConnect(item, dispat);

--- a/src/VDPRegViewer.h
+++ b/src/VDPRegViewer.h
@@ -20,7 +20,7 @@ public slots:
 	void receiveState(bool state);
 
 signals:
-	void dispatchState(bool state);
+	void stateDispatched(bool state);
 
 private:
 	int counter;

--- a/src/VDPStatusRegViewer.cpp
+++ b/src/VDPStatusRegViewer.cpp
@@ -15,13 +15,13 @@ void highlightDispatcher::receiveState(bool state)
 {
 	if (state) {
 		if (counter == 0) {
-			emit dispatchState(true);
+			emit stateDispatched(true);
 		}
 		++counter;
 	} else {
 		--counter;
 		if (counter == 0) {
-			emit dispatchState(false);
+			emit stateDispatched(false);
 		}
 	}
 }
@@ -110,7 +110,7 @@ void VDPStatusRegViewer::decodeVDPStatusRegs()
 void VDPStatusRegViewer::doConnect(InteractiveLabel* lab, highlightDispatcher* dis)
 {
 	connect(lab, SIGNAL(mouseOver(bool)),     dis, SLOT(receiveState(bool)));
-	connect(dis, SIGNAL(dispatchState(bool)), lab, SLOT(highlight(bool)));
+	connect(dis, SIGNAL(stateDispatched(bool)), lab, SLOT(highlight(bool)));
 }
 
 void VDPStatusRegViewer::makeGroup(QList<InteractiveLabel*> list, InteractiveLabel* explained)

--- a/src/VDPStatusRegViewer.h
+++ b/src/VDPStatusRegViewer.h
@@ -29,7 +29,7 @@ public slots:
 	void receiveState(bool state);
 
 signals:
-	void dispatchState(bool state);
+	void stateDispatched(bool state);
 
 private:
 	int counter;

--- a/src/VramBitMappedView.cpp
+++ b/src/VramBitMappedView.cpp
@@ -314,7 +314,7 @@ void VramBitMappedView::mouseMoveEvent(QMouseEvent* e)
 		default:
 			color = 0; // avoid warning
 	}
-	emit imagePosition(x, y, color, addr, val);
+	emit imageHovered(x, y, color, addr, val);
 }
 
 void VramBitMappedView::mousePressEvent(QMouseEvent* e)

--- a/src/VramBitMappedView.h
+++ b/src/VramBitMappedView.h
@@ -31,10 +31,10 @@ public slots:
 
 signals:
 	void imageChanged();
-	void imagePosition(int xcoormsx, int ycoormsx, int color,
-	                   unsigned addr, int byte);
-	void imageClicked (int xcoormsx, int ycoormsx, int color,
-	                   unsigned addr, int byte);
+	void imageHovered(int xcoormsx, int ycoormsx, int color,
+	                  unsigned addr, int byte);
+	void imageClicked(int xcoormsx, int ycoormsx, int color,
+	                  unsigned addr, int byte);
 
 private:
 	void paintEvent(QPaintEvent* e) override;

--- a/src/VramTiledView.cpp
+++ b/src/VramTiledView.cpp
@@ -550,7 +550,7 @@ void VramTiledView::mouseMoveEvent(QMouseEvent* e)
 	int y = 0;
 	int character = 0;
 	if (infoFromMouseEvent(e, x, y, character)) {
-		emit imagePosition(x, y, character);
+		emit imageHovered(x, y, character);
 	};
 }
 

--- a/src/VramTiledView.h
+++ b/src/VramTiledView.h
@@ -50,7 +50,7 @@ public slots:
     void refresh();
 
 signals:
-    void imagePosition(int screenx, int screeny, int character);
+    void imageHovered(int screenx, int screeny, int character);
     void imageClicked(int screenx, int screeny, int character, QString textinfo);
     void highlightCount(unsigned char character, int count);
 


### PR DESCRIPTION
Signals in Qt have passive voice form, so they use nouns+past tense verbs. And, since slots are just tagged methods, they follow the verb+object (or just verb) convention of functions and methods, unless the verb is "get", then it just vanishes in thin air (because this is not java).

**Warning:** This is not a comprehensive fix, since some signals and slots seem to follow some QtCreator name composition thing. Didn't want to touch that.