### PR TITLE
lambda functions parameters implemented as Command

### DIFF
--- a/src/CommClient.cpp
+++ b/src/CommClient.cpp
@@ -41,7 +41,7 @@ void CommClient::closeConnection()
 	}
 }
 
-void CommClient::sendCommand(Command* command)
+void CommClient::sendCommand(CommandBase* command)
 {
 	if (connection) {
 		connection->sendCommand(command);

--- a/src/CommClient.h
+++ b/src/CommClient.h
@@ -4,7 +4,7 @@
 #include <QObject>
 
 class OpenMSXConnection;
-class Command;
+class CommandBase;
 class QString;
 
 class CommClient : public QObject
@@ -13,7 +13,7 @@ class CommClient : public QObject
 public:
 	static CommClient& instance();
 
-	void sendCommand(Command* command);
+	void sendCommand(CommandBase* command);
 
 public slots:
 	void connectToOpenMSX(OpenMSXConnection* conn);

--- a/src/ConnectDialog.h
+++ b/src/ConnectDialog.h
@@ -43,7 +43,7 @@ private:
 
 // Command handler to get initial info from new openmsx connections
 
-class ConnectionInfoRequest : public QObject, Command
+class ConnectionInfoRequest : public QObject, CommandBase
 {
 	Q_OBJECT
 public:

--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -1132,8 +1132,8 @@ void DebuggerForm::executeStep()
 
 void DebuggerForm::executeStepOver()
 {
-	auto* sc = new SimpleCommand("step_over");
-	connect(sc, SIGNAL(replyStatusOk(bool)), this, SLOT(handleCommandReplyStatus(bool)));
+	auto* sc = new Command("step_over",
+		[this](const QString&){ finalizeConnection(true); });
 	comm.sendCommand(sc);
 	setRunMode();
 }
@@ -1153,17 +1153,10 @@ void DebuggerForm::executeStepOut()
 
 void DebuggerForm::executeStepBack()
 {
-	auto* sc = new SimpleCommand("step_back");
-	connect(sc, SIGNAL(replyStatusOk(bool)), this, SLOT(handleCommandReplyStatus(bool)));
+	auto* sc = new Command("step_back",
+		[this](const QString&){ finalizeConnection(true); });
 	comm.sendCommand(sc);
 	setRunMode();
-}
-
-void DebuggerForm::handleCommandReplyStatus(bool status)
-{
-	if (status) {
-		finalizeConnection(true);
-	}
 }
 
 void DebuggerForm::toggleBreakpoint(int addr)

--- a/src/DebuggerForm.h
+++ b/src/DebuggerForm.h
@@ -174,8 +174,6 @@ private slots:
 	void toggleBreakpoint(int addr = -1);
 	void addBreakpoint();
 
-	void handleCommandReplyStatus(bool status);
-
 	void toggleView(DockableWidget* widget);
 	void initConnection();
 	void handleUpdate(const QString& type, const QString& name,

--- a/src/OpenMSXConnection.cpp
+++ b/src/OpenMSXConnection.cpp
@@ -31,6 +31,38 @@ void SimpleCommand::cancel()
 }
 
 
+Command::Command(const QString& command,
+		std::function <void (const QString&)> okCallback,
+		std::function <void (const QString&)> errorCallback)
+		: command(command)
+		, okCallback(okCallback)
+		, errorCallback(errorCallback)
+{
+}
+
+void Command::replyOk(const QString& message)
+{
+	okCallback(message);
+	delete this;
+}
+
+void Command::replyNok(const QString& message)
+{
+	if (errorCallback != nullptr)
+		errorCallback(message);
+	cancel();
+}
+
+QString Command::getCommand() const
+{
+	return command;
+}
+
+void Command::cancel()
+{
+	delete this;
+}
+
 static QString createDebugCommand(const QString& debuggable,
 		unsigned offset, unsigned size)
 {
@@ -108,7 +140,7 @@ OpenMSXConnection::~OpenMSXConnection()
 	socket->deleteLater();
 }
 
-void OpenMSXConnection::sendCommand(Command* command)
+void OpenMSXConnection::sendCommand(CommandBase* command)
 {
 	assert(command);
 	if (connected && socket->isValid()) {
@@ -140,7 +172,7 @@ void OpenMSXConnection::cancelPending()
 {
 	assert(!connected);
 	while (!commands.empty()) {
-		Command* command = commands.dequeue();
+		CommandBase* command = commands.dequeue();
 		command->cancel();
 	}
 }
@@ -196,7 +228,7 @@ bool OpenMSXConnection::endElement(const QStringRef& qName)
 		// ignore
 	} else if (qName == "reply") {
 		if (connected) {
-			Command* command = commands.dequeue();
+			CommandBase* command = commands.dequeue();
 			if (xmlAttrs.value("result") == "ok") {
 				command->replyOk (xmlData);
 			} else {

--- a/src/OpenMSXConnection.cpp
+++ b/src/OpenMSXConnection.cpp
@@ -15,13 +15,11 @@ QString SimpleCommand::getCommand() const
 
 void SimpleCommand::replyOk (const QString& /*message*/)
 {
-	emit replyStatusOk(true);
 	delete this;
 }
 
 void SimpleCommand::replyNok(const QString& /*message*/)
 {
-	emit replyStatusOk(false);
 	cancel();
 }
 

--- a/src/OpenMSXConnection.h
+++ b/src/OpenMSXConnection.h
@@ -31,9 +31,6 @@ public:
 	void replyNok(const QString& message) override;
 	void cancel() override;
 
-signals:
-	void replyStatusOk(bool status);
-
 private:
 	QString command;
 };


### PR DESCRIPTION
This feature adds the power of lambda functions running on cascading events expressed as a simple inline. For instance, this is possible now:

```
CommClient::instance().sendCommand(new CascadingCommand("debug remove_bp bp#3",
        [this] (const QString&) { emit breakpointsChanged(); },    // success
        [this] (const QString& msg) { logError(msg); }             // fail
);
```
and it will run `emit breakpointsChanged();` if `debug remove_bp bp#3` command was successful or `logError(msg);` if it wasn't. Failing lambda function is optional and can be omitted. This feature requires C++11. 