### PR TITLE
Added case OnDemand to DisasmViewer::memoryUpdated

### DIFF
--- a/src/DisasmViewer.cpp
+++ b/src/DisasmViewer.cpp
@@ -144,7 +144,7 @@ void DisasmViewer::refresh()
 		disasmStart, disasmEnd - disasmStart, &memory[disasmStart], *this);
 	req->address = disasmLines[disasmTopLine].addr;
 	req->line = disasmLines[disasmTopLine].infoLine;
-	req->method = TopAlways;
+	req->method = OnDemand;
 
 	if (waitingForData) {
 		delete nextRequest;
@@ -357,8 +357,9 @@ void DisasmViewer::setAddress(quint16 addr, int infoLine, int method)
 	// openMSX and disassembled.
 
 	// determine disasm bounds
-	int disasmStart;
-	int disasmEnd;
+	int disasmStart = disasmLines.front().addr;
+	int disasmEnd = disasmLines.back().addr + disasmLines.back().numBytes;
+
 	int extra = 4 * (visibleLines > 9 ? visibleLines+partialBottomLine : 10);
 	switch (method) {
 	case Middle:
@@ -406,17 +407,26 @@ void DisasmViewer::memoryUpdated(CommMemoryRequest* req)
 	     memLayout, symTable, programAddr);
 
 	// locate the requested line
-	disasmTopLine = findDisasmLine(req->address, req->line);
+	int reqDisasmTopLine = findDisasmLine(req->address, req->line);
 
 	switch (req->method) {
 	case Middle:
 	case MiddleAlways:
-		disasmTopLine -= visibleLines / 2;
+		disasmTopLine = reqDisasmTopLine - visibleLines / 2;
 		break;
 	case Bottom:
 	case BottomAlways:
-		disasmTopLine -= visibleLines - 1;
+		disasmTopLine = reqDisasmTopLine - (visibleLines - 1);
 		break;
+	case OnDemand:
+		// Only change the topline if we're out of bounds
+		if (cursorAddr < disasmLines[disasmTopLine].addr ||
+            cursorAddr > disasmLines[disasmTopLine + visibleLines].addr) {
+			disasmTopLine = findDisasmLine(cursorAddr);
+		}
+		break;
+    default:
+        disasmTopLine = reqDisasmTopLine;
 	}
 
 	disasmTopLine = std::max(disasmTopLine, 0);
@@ -435,7 +445,7 @@ void DisasmViewer::memoryUpdated(CommMemoryRequest* req)
 		           this, SLOT(scrollBarChanged(int)));
 		// set the line
 		setAddress(disasmLines[disasmTopLine].addr,
-		           disasmLines[disasmTopLine].infoLine);
+		           disasmLines[disasmTopLine].infoLine, req->method);
 		update();
 	}
 }


### PR DESCRIPTION
Bugfix: DisasmViewer::memoryUpdated needs to be aware of the OnDemand case.
Also, initialize variables disasmStart and disasmEnd. Thanks @grauw for discovering this and letting me know.