### PR TITLE
github workflow compiles windows and gnu binaries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,14 +74,32 @@ jobs:
       run: |
         cd derived/bin
         if [ "${{ matrix.os }}" = "mingw" ]; then
-          cp -rp /usr/x86_64-w64-mingw32/bin .
-          cp -rp /usr/x86_64-w64-mingw32/lib/qt/plugins/imageformats .
-          cp -rp /usr/x86_64-w64-mingw32/lib/qt/plugins/iconengines .
-          cp -rp /usr/x86_64-w64-mingw32/lib/qt/plugins/platforms .
+          /usr/bin/x86_64-w64-mingw32-strip openmsx-debugger.exe
+          find /usr/x86_64-w64-mingw32 -name 'libbrotlicommon.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libbrotlidec.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libbz2-1.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libfreetype-6.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libgcc_s_seh-1.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libglib-2.0-0.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libgraphite2.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libharfbuzz-0.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libiconv-2.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libintl-8.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libpcre-1.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libpcre2-16-0.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libpng16-16.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libssp-0.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libstdc++-6.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'libwinpthread-1.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'Qt5Core.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'Qt5Gui.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'Qt5Network.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'Qt5Widgets.dll' -exec cp {} . \;
+          find /usr/x86_64-w64-mingw32 -name 'zlib1.dll' -exec cp {} . \;
         fi
     - name: Upload redistributable package for ${{ matrix.name }}
       uses: actions/upload-artifact@v3
       with:
-        #name: debugger-${{ steps.get_version.outputs.OPENMSX_VERSION }}-${{ env.target_cpu }}-${{ env.target_os }}-${{ env.package_origin }}.zip
-        name: ${{ steps.get_version.outputs.target_file }}.zip
+        #name: debugger-${{ steps.get_version.outputs.OPENMSX_VERSION }}-${{ env.target_cpu }}-${{ env.target_os }}-${{ env.package_origin }}
+        name: ${{ steps.get_version.outputs.target_file }}
         path: derived/bin

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,6 +96,8 @@ jobs:
           find /usr/x86_64-w64-mingw32 -name 'Qt5Network.dll' -exec cp {} . \;
           find /usr/x86_64-w64-mingw32 -name 'Qt5Widgets.dll' -exec cp {} . \;
           find /usr/x86_64-w64-mingw32 -name 'zlib1.dll' -exec cp {} . \;
+          mkdir platforms
+          cp -rp /usr/x86_64-w64-mingw32/lib/qt/plugins/platforms/qwindows.dll platforms/
         fi
     - name: Upload redistributable package for ${{ matrix.name }}
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,87 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+      - github-workflow
+  pull_request:
+    types:
+      - opened
+    branches:
+      - master
+
+env:
+  package_origin: gh
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+      options: --user=0:0
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: docker://pvmm/mingw-arch:latest
+            name: Windows
+            cpu: x86_64
+            os: mingw
+          - image: debian:unstable
+            name: GNU/Linux
+            cpu: x86_64
+            os: debian
+    steps:
+    - name: configure base system
+      run: |
+        if [ "${{ matrix.os }}" = "debian" ]; then
+          export DEBIAN_FRONTEND=noninteractive
+          export DEBCONF_NONINTERACTIVE_SEEN=true
+          apt-get -y update
+          apt-get -y install tzdata
+          echo "America/Sao_Paulo" > /etc/timezone
+          cp /etc/timezone /tz
+          cp /etc/localtime /tz
+          apt-get -y install git build-essential python3 qtbase5-dev qt5-qmake
+        fi
+        git config --global init.defaultBranch master
+    - name: checkout repository code
+      uses: actions/checkout@v3
+    - name: compile repository code
+      run: |
+        if [ "${{ matrix.os }}" = "mingw" ]; then
+          # Setting QT_INSTALL_BINS differently won't work since it's overwritten.
+          #export QT_INSTALL_BINS=/usr/x86_64-w64-mingw32/lib/qt/bin/
+          export OPENMSX_TARGET_OS=mingw32
+          export CXX=/usr/bin/x86_64-w64-mingw32-g++
+          export WINDRES=/usr/bin/x86_64-w64-mingw32-windres
+          ln -sf /usr/x86_64-w64-mingw32/lib/qt/bin/uic /usr/x86_64-w64-mingw32/bin/uic
+          ln -sf /usr/x86_64-w64-mingw32/lib/qt/bin/moc /usr/x86_64-w64-mingw32/bin/moc
+          ln -sf /usr/x86_64-w64-mingw32/lib/qt/bin/rcc /usr/x86_64-w64-mingw32/bin/rcc
+          QMAKE=/usr/x86_64-w64-mingw32/lib/qt/bin/qmake make
+        else
+          make
+        fi
+    - name: Determine version and file name
+      id: get_version
+      run: |
+        #DEBUGGER_VERSION=`python3 build/version.py`
+        #echo ::set-output name=DEBUGGER_VERSION::$DEBUGGER_VERSION
+        #echo "::set-output name=target_file::debugger-$DEBUGGER_VERSION-${{ matrix.cpu }}-${{ matrix.os }}-${{ env.package_origin }}"
+        echo "::set-output name=target_file::debugger-${{ matrix.cpu }}-${{ matrix.os }}-${{ env.package_origin }}"
+    - name: Prepare redistributable directory
+      run: |
+        cd derived/bin
+        if [ "${{ matrix.os }}" = "mingw" ]; then
+          cp -rp /usr/x86_64-w64-mingw32/bin .
+          cp -rp /usr/x86_64-w64-mingw32/lib/qt/plugins/imageformats .
+          cp -rp /usr/x86_64-w64-mingw32/lib/qt/plugins/iconengines .
+          cp -rp /usr/x86_64-w64-mingw32/lib/qt/plugins/platforms .
+        fi
+    - name: Upload redistributable package for ${{ matrix.name }}
+      uses: actions/upload-artifact@v3
+      with:
+        #name: debugger-${{ steps.get_version.outputs.OPENMSX_VERSION }}-${{ env.target_cpu }}-${{ env.target_os }}-${{ env.package_origin }}.zip
+        name: ${{ steps.get_version.outputs.target_file }}.zip
+        path: derived/bin

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ derived/
 build/msvc/.vs/*
 .vscode/
 __pycache__/
+.*.swp

--- a/src/ConnectDialog.cpp
+++ b/src/ConnectDialog.cpp
@@ -106,7 +106,7 @@ static OpenMSXConnection* createConnection(const QDir& dir, const QString& socke
 
 		QAbstractSocketStreamWrapper stream(socket);
 		SspiNegotiateClient client(stream);
-
+		
 		if (!socket->waitForConnected(1000) ||
 			!client.Authenticate()) {
 			delete socket;

--- a/src/openmsx/SspiUtils.cpp
+++ b/src/openmsx/SspiUtils.cpp
@@ -1,7 +1,6 @@
 #ifdef _WIN32
 
 #include "SspiUtils.h"
-#include "MSXException.h"
 #include <sddl.h>
 #include <cassert>
 
@@ -20,7 +19,8 @@ SspiPackageBase::SspiPackageBase(StreamWrapper& userStream, const SEC_WCHAR* sec
 	memset(&hContext, 0, sizeof(hContext));
 
 	if (!cbMaxTokenSize) {
-		throw MSXException("GetPackageMaxTokenSize failed");
+		// GetPackageMaxTokenSize failed
+		assert(false);
 	}
 }
 

--- a/src/openmsx/SspiUtils.h
+++ b/src/openmsx/SspiUtils.h
@@ -3,6 +3,7 @@
 
 #ifdef _WIN32
 
+#include <cstdint>
 #include <winsock2.h>
 #ifdef __GNUC__
 // MinGW32 requires that subauth.h be included before security.h, in order to define several things


### PR DESCRIPTION
I created the file `.github/workflows/build.yaml` that compiles the project for GNU and Windows (currently no Mac binary is generated). Tests may be necessary since I don't own a windows box to test the generated package. But the GNU binary works if you have Qt 5.15 pre-installed and btw that's why its package is so small compared to the Windows one.

Some missing files were included in `src/openmsx`, like `MSXException.hh` and files it depends upon.