### PR TITLE
new widget: table of breakpoints (BreakpointViewer)

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -259,8 +259,8 @@ CXXFLAGS:= -g -fPIC
 INCLUDE_INTERNAL:=$(sort $(foreach header,$(HEADERS_FULL),$(patsubst %/,%,$(dir $(header)))))
 INCLUDE_INTERNAL+=$(BUILD_PATH)/config
 COMPILE_FLAGS:=$(addprefix -I,$(QT_HEADER_DIRS) $(INCLUDE_INTERNAL) $(GEN_SRC_PATH))
-# Enable C++11
-COMPILE_FLAGS+=-std=c++11
+# Enable C++17
+COMPILE_FLAGS+=-std=c++17
 ifeq ($(OPENMSX_TARGET_OS),darwin)
 LINK_FLAGS:=-F$(QT_INSTALL_LIBS) $(addprefix -framework Qt,$(QT_COMPONENTS))
 OSX_VER:=10.13
@@ -283,7 +283,7 @@ DEPEND_FLAGS:=
 # Generic compilation flags.
 CXXFLAGS+=-pipe
 # Stricter warning and error reporting.
-CXXFLAGS+=-Wall
+CXXFLAGS+=-Wall -pedantic
 # Empty definition of used headers, so header removal doesn't break things.
 DEPEND_FLAGS+=-MP
 

--- a/src/BreakpointDialog.cpp
+++ b/src/BreakpointDialog.cpp
@@ -41,9 +41,9 @@ BreakpointDialog::~BreakpointDialog()
 	delete allCompleter;
 }
 
-Breakpoints::Type BreakpointDialog::type()
+Breakpoint::Type BreakpointDialog::type()
 {
-	return Breakpoints::Type(cmbxType->currentIndex());
+	return Breakpoint::Type(cmbxType->currentIndex());
 }
 
 int BreakpointDialog::address()
@@ -79,7 +79,7 @@ QString BreakpointDialog::condition()
 	return (cbCondition->checkState() == Qt::Checked) ? txtCondition->toPlainText() : "";
 }
 
-void BreakpointDialog::setData(Breakpoints::Type type, int address, qint8 ps, qint8 ss,
+void BreakpointDialog::setData(Breakpoint::Type type, int address, qint8 ps, qint8 ss,
                                qint16 segment, int addressEnd, QString condition)
 {
 	// set type

--- a/src/BreakpointDialog.h
+++ b/src/BreakpointDialog.h
@@ -17,7 +17,7 @@ public:
 	BreakpointDialog(const MemoryLayout& ml, DebugSession *session = nullptr, QWidget* parent = nullptr);
 	~BreakpointDialog() override;
 
-	Breakpoints::Type type();
+	Breakpoint::Type type();
 	int address();
 	int addressEndRange();
 	int slot();
@@ -25,7 +25,7 @@ public:
 	int segment();
 	QString condition();
 
-	void setData(Breakpoints::Type type, int address = -1,
+	void setData(Breakpoint::Type type, int address = -1,
 	             qint8 ps = -1, qint8 ss = -1, qint16 segment = -1,
 	             int addressEnd = -1, QString condition = QString());
 

--- a/src/BreakpointViewer.cpp
+++ b/src/BreakpointViewer.cpp
@@ -1,0 +1,600 @@
+#include "BreakpointViewer.h"
+#include "Convert.h"
+#include "CommClient.h"
+#include "OpenMSXConnection.h"
+#include "ScopedAssign.h"
+#include <QPainter>
+#include <QPaintEvent>
+#include <QMessageBox>
+#include <QToolTip>
+#include <QComboBox>
+#include <cassert>
+
+enum TableColumns {
+	ENABLED = 0,
+	WP_TYPE = 1,
+	LOCATION = 2,
+	BP_ADDRESS = 2,
+	WP_REGION = 2,
+	CONDITION = 3,
+	SLOT = 4,
+	SEGMENT = 5,
+};
+
+bool BreakpointViewer::ItemPos::operator==(const ItemPos& ip) const
+{
+	return (ip.type == type) && (ip.row == row);
+}
+
+BreakpointViewer::BreakpointViewer(QWidget* parent)
+	: QTabWidget(parent),
+	  ui(new Ui::BreakpointViewer)
+{
+	setupUi(this);
+	bpTableWidget->sortByColumn(BP_ADDRESS, Qt::AscendingOrder);
+	wpTableWidget->sortByColumn(WP_REGION, Qt::AscendingOrder);
+	bpTableWidget->setColumnHidden(WP_TYPE, true);
+	bpTableWidget->resizeColumnsToContents();
+	wpTableWidget->resizeColumnsToContents();
+
+	selector[0] = bpTableWidget;
+	selector[1] = wpTableWidget;
+	userMode = true;
+
+	connect(bpTableWidget, &QTableWidget::itemChanged, this,
+			&BreakpointViewer::changeBpTableItem);
+	connect(wpTableWidget, &QTableWidget::itemChanged, this,
+			&BreakpointViewer::changeWpTableItem);
+}
+
+// TODO: move the createSetCommand to a session manager
+void BreakpointViewer::createBreakpoint(Type type, int row)
+{
+	auto table = selector[type];
+	Breakpoint::Type type2;
+
+	if (type == WATCHPOINT) {
+		auto model = table->model();
+		auto combo = (QComboBox*) table->indexWidget(model->index(row, WP_TYPE));
+		type2 = static_cast<Breakpoint::Type>(combo->currentIndex() + 1);
+	} else {
+		type2 = Breakpoint::BREAKPOINT;
+	}
+
+	int address, endRange;
+	QString location = table->item(row, LOCATION)->text();
+	bool ok1 = processLocationField(-1, type, location, address, endRange);
+	if (!ok1) {
+		auto sa = ScopedAssign(userMode, false);
+		setBreakpointStatus(type, row, false);
+		return;
+	}
+
+	QString condition = table->item(row, CONDITION)->text();
+
+	qint8 ps, ss;
+	bool ok2 = processSlotField(-1, table->item(row, SLOT)->text(), ps, ss);
+	assert(ok2);
+
+	qint16 segment;
+	bool ok3 = processSegmentField(-1, table->item(row, SEGMENT)->text(), segment);
+	assert(ok3);
+
+	const QString cmdStr = Breakpoints::createSetCommand(type2, address, ps, ss, segment,
+			endRange, condition);
+	auto command = new Command(cmdStr,
+		[this] (const QString& result) {
+			emit contentsUpdated(false);
+		}
+	);
+	CommClient::instance().sendCommand(command);
+}
+
+// TODO: move the createRemoveCommand to a session manager
+void BreakpointViewer::replaceBreakpoint(Type type, int row)
+{
+	int index = items.indexOf({type, row});
+	assert(index != -1);
+
+	const QString& id = breakpoints->getBreakpoint(index).id;
+	const QString  cmdStr = breakpoints->createRemoveCommand(id);
+
+	auto command = new Command(cmdStr,
+		[this, type, row] (const QString& result) {
+			createBreakpoint(type, row);
+		}
+	);
+	CommClient::instance().sendCommand(command);
+}
+
+// TODO: move the createRemoveCommand to a session manager
+void BreakpointViewer::removeBreakpoint(Type type, int row)
+{
+	int index = items.indexOf({type, row});
+
+	const QString& id     = breakpoints->getBreakpoint(index).id;
+	const QString  cmdStr = Breakpoints::createRemoveCommand(id);
+
+	auto command = new Command(cmdStr,
+		[this] (const QString& result) {
+			emit contentsUpdated(false);
+	});
+	CommClient::instance().sendCommand(command);
+}
+
+void BreakpointViewer::setBreakpointStatus(Type type, int row, int status)
+{
+	auto table = selector[type];
+	auto item = table->item(row, ENABLED);
+	item->setFlags(status
+		? item->flags() |  Qt::ItemIsEnabled
+		: item->flags() & ~Qt::ItemIsEnabled);
+}
+
+bool BreakpointViewer::processSlotField(int index, const QString& field, qint8& ps, qint8& ss)
+{
+	QStringList s = field.simplified().split("/", Qt::SplitBehaviorFlags::SkipEmptyParts);
+
+	if (s[0].compare("X", Qt::CaseInsensitive)) {
+		bool ok;
+		int value = s[0].toInt(&ok);
+		if (!ok || (value < 0 && value > 3)) {
+			// restore value
+			if (index != -1) {
+				ps = breakpoints->getBreakpoint(index).ps;
+			} else {
+				return false;
+			}
+		} else {
+			ps = value;
+		}
+	} else {
+		ps = -1;
+	}
+	if (s.size() == 2 && s[1].compare("X", Qt::CaseInsensitive)) {
+		bool ok;
+		int value = s[1].toInt(&ok);
+		if (!ok || (value < 0 && value > 3)) {
+			if (index != -1) {
+				ss = breakpoints->getBreakpoint(index).ss;
+			} else {
+				return false;
+			}
+		} else {
+			ss = value;
+		}
+	} else {
+		ss = -1;
+	}
+	return true;
+}
+
+bool BreakpointViewer::processSegmentField(int index, const QString& field, qint16& segment)
+{
+	QString s = field.simplified();
+
+	if (s.compare("X", Qt::CaseInsensitive)) {
+		bool ok;
+		int value = field.toInt(&ok);
+		if (!ok || (value < 0 && value > 255)) {
+			if (index != -1) {
+				segment = breakpoints->getBreakpoint(index).segment;
+			} else {
+				return false;
+			}
+		} else {
+			segment = value;
+		}
+	} else {
+		segment = -1;
+	}
+	return true;
+}
+
+bool BreakpointViewer::processLocationField(int index, BreakpointViewer::Type type,
+		const QString& field, int& begin, int& end)
+{
+	if (type == BreakpointViewer::BREAKPOINT) {
+		if (int value = stringToValue(field.simplified()); value != -1) {
+			begin = 0xFFFF & value;
+			end = -1;
+			return true;
+		} else if (index != -1) {
+			begin = breakpoints->getBreakpoint(index).address;
+			end = -1;
+			return true;
+		}
+		return false;
+	}
+
+	QStringList s = field.simplified().split(":", Qt::SplitBehaviorFlags::SkipEmptyParts);
+	begin = (s.size() >= 1) ? stringToValue(s[0]) : -1;
+	end   = (s.size() == 2) ? stringToValue(s[1]) : (s.size() == 1 ? begin : -1);
+	if (begin != -1 && end != -1 && end >= begin) return true;
+
+	if (index == -1) return false;
+	auto bp = breakpoints->getBreakpoint(index);
+	begin = bp.address;
+	end = bp.regionEnd;
+	return true;
+}
+
+void BreakpointViewer::changeTableItem(Type type, QTableWidgetItem* item)
+{
+	auto table = selector[type];
+
+	// trying to modify a bp instead of creating a new one
+	bool createBp = false;
+
+	// check if breakpoint is enabled
+	int row = table->row(item);
+	int index = items.indexOf({type, row});
+	QTableWidgetItem* enabledItem = table->item(row, ENABLED);
+	bool enabled = enabledItem->checkState() == Qt::Checked;
+
+	switch (table->column(item)) {
+		case ENABLED:
+			createBp = enabled;
+			break;
+		case WP_TYPE:
+			assert(table == wpTableWidget);
+			if (!enabled) return;
+			break;
+		case LOCATION: {
+			int adrLen;
+
+			if (type == WATCHPOINT) {
+				auto model = table->model();
+				auto combo = (QComboBox*) table->indexWidget(model->index(row, WP_TYPE));
+				Breakpoint::Type wtype = static_cast<Breakpoint::Type>(combo->currentIndex() + 1);
+				adrLen = (wtype == Breakpoint::WATCHPOINT_IOREAD || wtype == Breakpoint::WATCHPOINT_IOWRITE)
+					? 2 : 4;
+			} else {
+				adrLen = 4;
+			}
+			int begin, end;
+
+			if (processLocationField(index, type, item->text(), begin, end)) {
+				auto sa = ScopedAssign(userMode, false);
+				item->setText(QString("%1%2%3").arg(hexValue(begin, adrLen))
+					.arg(end == begin || end == -1 ? "" : ":")
+					.arg(end == begin || end == -1 ? "" : hexValue(end, adrLen)));
+				setBreakpointStatus(type, row, true);
+			} else {
+				auto sa = ScopedAssign(userMode, false);
+				enabled = false;
+				item->setText("");
+				setBreakpointStatus(type, row, false);
+			}
+			if (!enabled) return;
+			break;
+		}
+		case SLOT: {
+			qint8 ps, ss;
+			if (processSlotField(index, item->text(), ps, ss)) {
+				auto sa = ScopedAssign(userMode, false);
+				item->setText(QString("%1/%2")
+					.arg(ps == -1 ? QChar('X') : QChar('0' + ps))
+					.arg(ss == -1 ? QChar('X') : QChar('0' + ss)));
+			} else {
+				auto sa = ScopedAssign(userMode, false);
+				item->setText("X/X");
+			}
+			if (!enabled) return;
+			break;
+		}
+		case SEGMENT: {
+			qint16 segment;
+			if (processSegmentField(index, item->text(), segment)) {
+				auto sa = ScopedAssign(userMode, false);
+				item->setText(QString("%1").arg(segment == -1 ? "X" : QString::number(segment)));
+			} else {
+				auto sa = ScopedAssign(userMode, false);
+				item->setText("X");
+			}
+			if (!enabled) return;
+			break;
+		}
+		case CONDITION: {
+			auto sa = ScopedAssign(userMode, false);
+			item->setText(item->text().simplified());
+			if (!enabled) return;
+			break;
+		}
+	}
+
+	if (enabled) {
+		if (createBp) {
+			createBreakpoint(type, row);
+		} else {
+			replaceBreakpoint(type, row);
+		}
+	} else if (index != -1) {
+		removeBreakpoint(type, row);
+	} else {
+		assert(index != -1);
+	}
+}
+
+void BreakpointViewer::changeBpTableItem(QTableWidgetItem* item)
+{
+	if (!userMode) return;
+	changeTableItem(BREAKPOINT, item);
+}
+
+void BreakpointViewer::changeWpTableItem(QTableWidgetItem* item)
+{
+	if (!userMode) return;
+	changeTableItem(WATCHPOINT, item);
+}
+
+void BreakpointViewer::setBreakpoints(Breakpoints* bps)
+{
+	breakpoints = bps;
+}
+
+void BreakpointViewer::keepUnusedItems()
+{
+	int row = 0;
+
+	while (row < bpTableWidget->rowCount()) {
+		QTableWidgetItem* enabledItem = bpTableWidget->item(row, ENABLED);
+		bool enabled = enabledItem->checkState() == Qt::Checked;
+		if (enabled) {
+			bpTableWidget->removeRow(row);
+		} else {
+			row++;
+		}
+	}
+
+	while (row < wpTableWidget->rowCount()) {
+		QTableWidgetItem* enabledItem = wpTableWidget->item(row, ENABLED);
+		bool enabled = enabledItem->checkState() == Qt::Checked;
+		if (enabled) {
+			wpTableWidget->removeRow(row);
+		} else {
+			row++;
+		}
+	}
+}
+
+void BreakpointViewer::setRunState()
+{
+	runState = true;
+}
+
+void BreakpointViewer::setBreakState()
+{
+	runState = false;
+}
+
+void BreakpointViewer::sync()
+{
+	items.clear();
+
+	auto sa = ScopedAssign(userMode, false);
+	keepUnusedItems();
+
+	int bpRow = bpTableWidget->rowCount();
+	int wpRow = wpTableWidget->rowCount();
+
+	if (breakpoints->breakpointCount() != -1) {
+		for (int index = 0; index < breakpoints->breakpointCount(); ++index) {
+			const Breakpoint& bp = breakpoints->getBreakpoint(index);
+
+			switch (bp.type) {
+			case Breakpoint::BREAKPOINT: {
+				bpRow = createTableRow(BREAKPOINT);
+				setBreakpointStatus(BREAKPOINT, bpRow, true);
+
+				bool currentSlot = breakpoints->inCurrentSlot(bp);
+				QBrush color = palette().brush(runState | currentSlot ?
+					QPalette::ColorGroup::Normal : QPalette::ColorGroup::Disabled,
+					QPalette::WindowText);
+
+				QTableWidgetItem* item1 = bpTableWidget->item(bpRow, ENABLED);
+				item1->setCheckState(Qt::Checked);
+
+				QTableWidgetItem* item2 = bpTableWidget->item(bpRow, BP_ADDRESS);
+				item2->setForeground(color);
+				item2->setText(hexValue(bp.address, 4));
+
+				QTableWidgetItem* item3 = bpTableWidget->item(bpRow, CONDITION);
+				item3->setForeground(color);
+				item3->setText(bp.condition.trimmed());
+
+				QTableWidgetItem* item4 = bpTableWidget->item(bpRow, SLOT);
+				item4->setForeground(color);
+				item4->setText(QString("%1/%2")
+					.arg(bp.ps == -1 ? QChar('X') : QChar('0' + bp.ps))
+					.arg(bp.ss == -1 ? QChar('X') : QChar('0' + bp.ss)));
+
+				QTableWidgetItem* item5 = bpTableWidget->item(bpRow, SEGMENT);
+				item5->setForeground(color);
+				item5->setText(bp.segment == -1 ? "X" : QString("%1").arg(bp.segment));
+
+				items.append({BREAKPOINT, bpTableWidget->row(item5)});
+				break;
+			}
+			case Breakpoint::WATCHPOINT_MEMREAD:
+			case Breakpoint::WATCHPOINT_MEMWRITE:
+			case Breakpoint::WATCHPOINT_IOREAD:
+			case Breakpoint::WATCHPOINT_IOWRITE: {
+				wpRow = createTableRow(WATCHPOINT);
+				setBreakpointStatus(WATCHPOINT, wpRow, true);
+
+				bool currentSlot = (bp.type == Breakpoint::WATCHPOINT_MEMREAD
+				                 || bp.type == Breakpoint::WATCHPOINT_MEMWRITE)
+				                  ? breakpoints->inCurrentSlot(bp) : true;
+				QBrush color = palette().brush(runState | currentSlot ?
+					QPalette::ColorGroup::Normal : QPalette::ColorGroup::Disabled,
+					QPalette::WindowText);
+
+				QTableWidgetItem* item1 = wpTableWidget->item(wpRow, ENABLED);
+				item1->setCheckState(Qt::Checked);
+
+				auto model = wpTableWidget->model();
+				auto combo = (QComboBox*) wpTableWidget->indexWidget(model->index(wpRow, WP_TYPE));
+				combo->setCurrentIndex(static_cast<int>(bp.type) - 1);
+				int adrLen = (bp.type == Breakpoint::WATCHPOINT_IOREAD
+				           || bp.type == Breakpoint::WATCHPOINT_IOWRITE) ? 2 : 4;
+
+				QString address = hexValue(bp.address, adrLen);
+				QString regionEnd = hexValue(bp.regionEnd, adrLen);
+				QTableWidgetItem* item2 = wpTableWidget->item(wpRow, WP_REGION);
+				item2->setForeground(color);
+				item2->setText(QString("%1%2%3").arg(address)
+						.arg(regionEnd == -1 || regionEnd == address ? "" : ":")
+						.arg(regionEnd == -1 || regionEnd == address ? "" : regionEnd));
+
+				QTableWidgetItem* item3 = wpTableWidget->item(wpRow, CONDITION);
+				item3->setForeground(color);
+				item3->setText(bp.condition.trimmed());
+
+				QTableWidgetItem* item4 = wpTableWidget->item(wpRow, SLOT);
+				item4->setForeground(color);
+				item4->setText(QString("%1/%2")
+					.arg(bp.ps == -1 ? QChar('X') : QChar('0' + bp.ps))
+					.arg(bp.ss == -1 ? QChar('X') : QChar('0' + bp.ss)));
+
+				QTableWidgetItem* item5 = wpTableWidget->item(wpRow, SEGMENT);
+				item5->setForeground(color);
+				item5->setText(bp.segment == -1 ? "X" : QString("%1").arg(bp.segment));
+
+				items.append({WATCHPOINT, wpTableWidget->row(item5)});
+				break;
+			}
+			case Breakpoint::CONDITION:
+				if (!conditionsMsg) {
+					QMessageBox::information(
+						this,
+						"Not yet implemented",
+						"Sorry, the condition manager is not yet implemented");
+					conditionsMsg = true;
+				}
+				break;
+			default:
+				assert(false);
+			}
+		}
+	}
+
+ 	bpTableWidget->resizeColumnsToContents();
+ 	wpTableWidget->resizeColumnsToContents();
+}
+
+void BreakpointViewer::changeCurrentWpType(int row, int selected)
+{
+	if (!userMode) return;
+	auto item = wpTableWidget->item(row, WP_TYPE);
+	changeTableItem(WATCHPOINT, item);
+}
+
+void BreakpointViewer::createComboBox(int row)
+{
+	auto combo = new QComboBox();
+	combo->setEditable(false);
+	combo->insertItem(0, "write_io");
+	combo->insertItem(0, "read_io");
+	combo->insertItem(0, "write_mem");
+	combo->insertItem(0, "read_mem");
+
+	auto model = wpTableWidget->model();
+	auto index = model->index(row, WP_TYPE);
+
+	wpTableWidget->setIndexWidget(index, combo);
+
+	connect(combo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+		[this, row](int index){ changeCurrentWpType(row, index); });
+}
+
+int BreakpointViewer::createTableRow(Type type)
+{
+	auto sa = ScopedAssign(userMode, false);
+
+	auto table = selector[type];
+	int row = table->rowCount();
+	table->setRowCount(row + 1);
+	table->selectRow(row);
+
+	QTableWidgetItem* item1 = new QTableWidgetItem();
+	item1->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsSelectable);
+	item1->setCheckState(Qt::Unchecked);
+	table->setItem(row, ENABLED, item1);
+
+	// type
+	QTableWidgetItem* item2 = new QTableWidgetItem();
+	item2->setTextAlignment(Qt::AlignCenter);
+	table->setItem(row, WP_TYPE, item2);
+	if (type == WATCHPOINT) {
+		createComboBox(row);
+	}
+
+	// address
+	QTableWidgetItem* item3 = new QTableWidgetItem();
+	item3->setTextAlignment(Qt::AlignCenter);
+	table->setItem(row, LOCATION, item3);
+
+	// ps/ss
+	QTableWidgetItem* item4 = new QTableWidgetItem();
+	item4->setTextAlignment(Qt::AlignCenter);
+	item4->setText("X/X");
+	table->setItem(row, SLOT, item4);
+
+	// segment
+	QTableWidgetItem* item5 = new QTableWidgetItem();
+	item5->setTextAlignment(Qt::AlignCenter);
+	item5->setText("X");
+	table->setItem(row, SEGMENT, item5);
+
+	// condition
+	QTableWidgetItem* item6 = new QTableWidgetItem();
+	item6->setTextAlignment(Qt::AlignCenter);
+	table->setItem(row, CONDITION, item6);
+
+ 	table->resizeColumnsToContents();
+
+	return row;
+}
+
+void BreakpointViewer::on_btnAddBp_clicked()
+{
+	auto sa = ScopedAssign(userMode, false);
+	int row = createTableRow(BREAKPOINT);
+	setBreakpointStatus(BREAKPOINT, row, false);
+}
+
+void BreakpointViewer::on_btnRemoveBp_clicked()
+{
+	if (bpTableWidget->currentRow() == -1)
+		return;
+
+	auto sa = ScopedAssign(userMode, false);
+	QTableWidgetItem* item = bpTableWidget->item(bpTableWidget->currentRow(), ENABLED);
+	if (item->checkState() == Qt::Checked) {
+		removeBreakpoint(BREAKPOINT, bpTableWidget->currentRow());
+	}
+	bpTableWidget->removeRow(bpTableWidget->currentRow());
+	bpTableWidget->resizeColumnsToContents();
+}
+
+void BreakpointViewer::on_btnAddWp_clicked()
+{
+	auto sa = ScopedAssign(userMode, false);
+	int row = createTableRow(WATCHPOINT);
+	setBreakpointStatus(WATCHPOINT, row, false);
+}
+
+void BreakpointViewer::on_btnRemoveWp_clicked()
+{
+	if (wpTableWidget->currentRow() == -1)
+		return;
+
+	auto sa = ScopedAssign(userMode, false);
+	QTableWidgetItem* item = wpTableWidget->item(wpTableWidget->currentRow(), ENABLED);
+	if (item->checkState() == Qt::Checked) {
+		removeBreakpoint(WATCHPOINT, wpTableWidget->currentRow());
+	}
+	wpTableWidget->removeRow(wpTableWidget->currentRow());
+	wpTableWidget->resizeColumnsToContents();
+}

--- a/src/BreakpointViewer.h
+++ b/src/BreakpointViewer.h
@@ -16,11 +16,11 @@ public:
 	BreakpointViewer(QWidget* parent = nullptr);
 	void setBreakpoints(Breakpoints* bps);
 
-	enum Type { BREAKPOINT, WATCHPOINT };
+	enum Type { BREAKPOINT, WATCHPOINT, CONDITION };
 
 private:
 	Ui::BreakpointViewer* ui;
-	QTableWidget* selector[2];
+	QTableWidget* selector[3];
 
 	// layout
 	int frameL, frameR, frameT, frameB;
@@ -32,15 +32,8 @@ private:
 	bool conditionsMsg = false;
 	Breakpoints* breakpoints;
 
-	struct ItemPos {
-		BreakpointViewer::Type type;
-		int row;
-		bool operator==(const ItemPos& ip) const;
-	};
-	QList<ItemPos> items;
-
 	bool processLocationField(int index, BreakpointViewer::Type type, const QString& field,
-		int& begin, int& end);
+		int& begin, int& end, const QString combo = QString());
 	bool processSlotField(int index, const QString& field, qint8& ps, qint8& ss);
 	bool processSegmentField(int index, const QString& field, qint16& segment);
 	void changeTableItem(Type type, QTableWidgetItem* item);
@@ -48,6 +41,9 @@ private:
 	int createTableRow(Type type);
 
 	void createBreakpoint(Type type, int row);
+	void _createBreakpoint(Type type, int row);
+	void _createCondition(int row);
+
 	void replaceBreakpoint(Type type, int row);
 	void removeBreakpoint(Type type, int row);
 	void setBreakpointStatus(Type type, int row, int status);
@@ -57,12 +53,16 @@ private slots:
 	void changeCurrentWpType(int row, int index);
 	void changeBpTableItem(QTableWidgetItem* item);
 	void changeWpTableItem(QTableWidgetItem* item);
+	void changeCnTableItem(QTableWidgetItem* item);
 
 public slots:
 	void on_btnAddBp_clicked();
 	void on_btnRemoveBp_clicked();
 	void on_btnAddWp_clicked();
 	void on_btnRemoveWp_clicked();
+	void on_btnAddCn_clicked();
+	void on_btnRemoveCn_clicked();
+
 	void setRunState();
 	void setBreakState();
 	void sync();

--- a/src/BreakpointViewer.h
+++ b/src/BreakpointViewer.h
@@ -1,0 +1,74 @@
+#ifndef BREAKPOINTVIEWER_H
+#define BREAKPOINTVIEWER_H
+
+#include "ui_BreakpointViewer.h"
+#include "DebuggerData.h"
+#include <QList>
+#include <QTabWidget>
+
+class QPaintEvent;
+class Breakpoints;
+
+class BreakpointViewer : public QTabWidget, private Ui::BreakpointViewer
+{
+	Q_OBJECT
+public:
+	BreakpointViewer(QWidget* parent = nullptr);
+	void setBreakpoints(Breakpoints* bps);
+
+	enum Type { BREAKPOINT, WATCHPOINT };
+
+private:
+	Ui::BreakpointViewer* ui;
+	QTableWidget* selector[2];
+
+	// layout
+	int frameL, frameR, frameT, frameB;
+	int leftRegPos, leftValuePos, rightRegPos, rightValuePos;
+	int rowHeight;
+	int cursorLoc;
+	bool userMode;
+	bool runState;
+	bool conditionsMsg = false;
+	Breakpoints* breakpoints;
+
+	struct ItemPos {
+		BreakpointViewer::Type type;
+		int row;
+		bool operator==(const ItemPos& ip) const;
+	};
+	QList<ItemPos> items;
+
+	bool processLocationField(int index, BreakpointViewer::Type type, const QString& field,
+		int& begin, int& end);
+	bool processSlotField(int index, const QString& field, qint8& ps, qint8& ss);
+	bool processSegmentField(int index, const QString& field, qint16& segment);
+	void changeTableItem(Type type, QTableWidgetItem* item);
+	void createComboBox(int row);
+	int createTableRow(Type type);
+
+	void createBreakpoint(Type type, int row);
+	void replaceBreakpoint(Type type, int row);
+	void removeBreakpoint(Type type, int row);
+	void setBreakpointStatus(Type type, int row, int status);
+	void keepUnusedItems();
+
+private slots:
+	void changeCurrentWpType(int row, int index);
+	void changeBpTableItem(QTableWidgetItem* item);
+	void changeWpTableItem(QTableWidgetItem* item);
+
+public slots:
+	void on_btnAddBp_clicked();
+	void on_btnRemoveBp_clicked();
+	void on_btnAddWp_clicked();
+	void on_btnRemoveWp_clicked();
+	void setRunState();
+	void setBreakState();
+	void sync();
+
+signals:
+	void contentsUpdated(bool merge);
+};
+
+#endif // BREAKPOINTVIEWER_H

--- a/src/BreakpointViewer.ui
+++ b/src/BreakpointViewer.ui
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>BreakpointViewer</class>
+ <widget class="QTabWidget" name="BreakpointViewer">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>250</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>310</width>
+    <height>150</height>
+   </size>
+  </property>
+  <property name="currentIndex">
+   <number>0</number>
+  </property>
+  <property name="elideMode">
+   <enum>Qt::ElideRight</enum>
+  </property>
+  <property name="documentMode">
+   <bool>true</bool>
+  </property>
+  <property name="movable">
+   <bool>true</bool>
+  </property>
+  <widget class="QWidget" name="tabBpLabel">
+   <attribute name="title">
+    <string>Breakpoints</string>
+   </attribute>
+   <layout class="QHBoxLayout">
+    <property name="leftMargin">
+     <number>2</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="QTableWidget" name="bpTableWidget">
+      <property name="frameShape">
+       <enum>QFrame::WinPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Sunken</enum>
+      </property>
+      <property name="lineWidth">
+       <number>0</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <attribute name="horizontalHeaderVisible">
+       <bool>true</bool>
+      </attribute>
+      <attribute name="horizontalHeaderMinimumSectionSize">
+       <number>10</number>
+      </attribute>
+      <attribute name="horizontalHeaderDefaultSectionSize">
+       <number>120</number>
+      </attribute>
+      <attribute name="horizontalHeaderStretchLastSection">
+       <bool>false</bool>
+      </attribute>
+      <attribute name="verticalHeaderVisible">
+       <bool>false</bool>
+      </attribute>
+      <column>
+       <property name="text">
+        <string>X</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Type</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Address</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Condition</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Slot</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Segment</string>
+       </property>
+      </column>
+     </widget>
+    </item>
+    <item>
+     <layout class="QVBoxLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="btnAddBp">
+        <property name="text">
+         <string>Add</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnRemoveBp">
+        <property name="text">
+         <string>Remove</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="tabWpLabel">
+   <attribute name="title">
+    <string>Watchpoints</string>
+   </attribute>
+   <layout class="QHBoxLayout">
+    <property name="leftMargin">
+     <number>2</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="QTableWidget" name="wpTableWidget">
+      <property name="frameShape">
+       <enum>QFrame::WinPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Sunken</enum>
+      </property>
+      <property name="lineWidth">
+       <number>0</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <attribute name="horizontalHeaderVisible">
+       <bool>true</bool>
+      </attribute>
+      <attribute name="horizontalHeaderMinimumSectionSize">
+       <number>10</number>
+      </attribute>
+      <attribute name="horizontalHeaderDefaultSectionSize">
+       <number>120</number>
+      </attribute>
+      <attribute name="horizontalHeaderStretchLastSection">
+       <bool>false</bool>
+      </attribute>
+      <attribute name="verticalHeaderVisible">
+       <bool>false</bool>
+      </attribute>
+      <column>
+       <property name="text">
+        <string>X</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Type</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Region</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Condition</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Slot</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Segment</string>
+       </property>
+      </column>
+     </widget>
+    </item>
+    <item>
+     <layout class="QVBoxLayout" name="wpLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="btnAddWp">
+        <property name="text">
+         <string>Add</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnRemoveWp">
+        <property name="text">
+         <string>Remove</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/BreakpointViewer.ui
+++ b/src/BreakpointViewer.ui
@@ -110,6 +110,11 @@
         <string>Segment</string>
        </property>
       </column>
+      <column>
+       <property name="text">
+        <string>#</string>
+       </property>
+      </column>
      </widget>
     </item>
     <item>
@@ -227,6 +232,11 @@
         <string>Segment</string>
        </property>
       </column>
+      <column>
+       <property name="text">
+        <string>#</string>
+       </property>
+      </column>
      </widget>
     </item>
     <item>
@@ -246,6 +256,128 @@
       </item>
       <item>
        <widget class="QPushButton" name="btnRemoveWp">
+        <property name="text">
+         <string>Remove</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="tabCnLabel">
+   <attribute name="title">
+    <string>Conditions</string>
+   </attribute>
+   <layout class="QHBoxLayout">
+    <property name="leftMargin">
+     <number>2</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="QTableWidget" name="cnTableWidget">
+      <property name="frameShape">
+       <enum>QFrame::WinPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Sunken</enum>
+      </property>
+      <property name="lineWidth">
+       <number>0</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <attribute name="horizontalHeaderVisible">
+       <bool>true</bool>
+      </attribute>
+      <attribute name="horizontalHeaderMinimumSectionSize">
+       <number>10</number>
+      </attribute>
+      <attribute name="horizontalHeaderDefaultSectionSize">
+       <number>120</number>
+      </attribute>
+      <attribute name="horizontalHeaderStretchLastSection">
+       <bool>false</bool>
+      </attribute>
+      <attribute name="verticalHeaderVisible">
+       <bool>false</bool>
+      </attribute>
+      <column>
+       <property name="text">
+        <string>X</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Type</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Address</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Condition</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Slot</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Segment</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>#</string>
+       </property>
+      </column>
+     </widget>
+    </item>
+    <item>
+     <layout class="QVBoxLayout" name="cnLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="btnAddCn">
+        <property name="text">
+         <string>Add</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnRemoveCn">
         <property name="text">
          <string>Remove</string>
         </property>

--- a/src/CPURegsViewer.h
+++ b/src/CPURegsViewer.h
@@ -7,7 +7,7 @@ class QPaintEvent;
 
 class CPURegsViewer : public QFrame
 {
-	Q_OBJECT;
+	Q_OBJECT
 public:
 	CPURegsViewer(QWidget* parent = nullptr);
 

--- a/src/DebuggerData.h
+++ b/src/DebuggerData.h
@@ -19,58 +19,56 @@ struct MemoryLayout
 	int mapperSize[4][4];
 };
 
+struct Breakpoint {
+	enum Type { BREAKPOINT, WATCHPOINT_MEMREAD, WATCHPOINT_MEMWRITE,
+	            WATCHPOINT_IOREAD, WATCHPOINT_IOWRITE, CONDITION };
+	Type type;
+	QString id;
+	quint16 address;
+	// end for watchpoint region
+	quint16 regionEnd;
+	// gui specific condition variables
+	qint8 ps;
+	qint8 ss;
+	qint16 segment;
+	// general condition
+	QString condition;
+	// compare content
+	bool operator==(const Breakpoint &bp) const;
+};
+
 class Breakpoints
 {
 public:
-	Breakpoints();
-
-	enum Type { BREAKPOINT = 0, WATCHPOINT_MEMREAD, WATCHPOINT_MEMWRITE,
-	            WATCHPOINT_IOREAD, WATCHPOINT_IOWRITE, CONDITION };
-
 	void clear();
 
 	void setMemoryLayout(MemoryLayout* ml);
 	void setBreakpoints(const QString& str);
 	QString mergeBreakpoints(const QString& str);
 	int breakpointCount();
-	bool isBreakpoint(quint16 addr, QString *id = nullptr);
-	bool isWatchpoint(quint16 addr, QString *id = nullptr);
+	bool isBreakpoint(quint16 addr, QString *id = nullptr, bool checkSlot = true);
+	bool isWatchpoint(quint16 addr, QString *id = nullptr, bool checkSlot = true);
 
 	/* xml session file functions */
 	void saveBreakpoints(QXmlStreamWriter& xml);
 	void loadBreakpoints(QXmlStreamReader& xml);
 
 	int findBreakpoint(quint16 addr);
-	int findNextBreakpoint();
 
-	static QString createSetCommand(Type type, int address,
+	static QString createSetCommand(Breakpoint::Type type, quint16 address,
 	                                qint8 ps = -1, qint8 ss = -1, qint16 segment = -1,
 	                                int endRange = -1, QString condition = QString());
 	static QString createRemoveCommand(const QString& id);
 
+	const Breakpoint& getBreakpoint(int index);
+	bool inCurrentSlot(const Breakpoint& bp);
 private:
-	struct Breakpoint {
-		Type type;
-		QString id;
-		quint16 address;
-		// end for watchpoint region
-		quint16 regionEnd;
-		// gui specific condition variables
-		qint8 ps;
-		qint8 ss;
-		qint16 segment;
-		// general condition
-		QString condition;
-		// compare content
-		bool operator==(const Breakpoint &bp) const;
-	};
 
 	std::vector<Breakpoint> breakpoints;
-	MemoryLayout* memLayout;
+	MemoryLayout* memLayout = nullptr;
 
 	void parseCondition(Breakpoint& bp);
 	void insertBreakpoint(Breakpoint& bp);
-	bool inCurrentSlot(const Breakpoint& bp);
 };
 
 #endif // DEBUGGERDATA_H

--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -81,41 +81,6 @@ private:
 };
 
 
-class ListBreakPointsHandler : public SimpleCommand
-{
-public:
-	ListBreakPointsHandler(DebuggerForm& form_, bool merge_ = false)
-		: SimpleCommand("debug_list_all_breaks")
-		, form(form_), merge(merge_)
-	{
-	}
-
-	void replyOk(const QString& message) override
-	{
-		if (merge) {
-			QString bps = form.session.breakpoints().mergeBreakpoints(message);
-			if (!bps.isEmpty()) {
-				form.comm.sendCommand(new SimpleCommand(bps));
-				form.comm.sendCommand(new ListBreakPointsHandler(form, false));
-			} else {
-				form.disasmView->update();
-				form.session.sessionModified();
-				form.updateWindowTitle();
-			}
-		} else {
-			form.session.breakpoints().setBreakpoints(message);
-			form.disasmView->update();
-			form.session.sessionModified();
-			form.updateWindowTitle();
-		}
-		delete this;
-	}
-private:
-	DebuggerForm& form;
-	bool merge;
-};
-
-
 class CPURegRequest : public ReadDebugBlockCommand
 {
 public:
@@ -940,7 +905,7 @@ void DebuggerForm::breakOccured()
 
 void DebuggerForm::updateData()
 {
-	comm.sendCommand(new ListBreakPointsHandler(*this, mergeBreakpoints));
+	reloadBreakpoints(mergeBreakpoints);
 	// only merge the first time after connect
 	mergeBreakpoints = false;
 
@@ -1010,7 +975,7 @@ void DebuggerForm::openSession(const QString& file)
 	session.open(file);
 	if (systemDisconnectAction->isEnabled()) {
 		// active connection, merge loaded breakpoints
-		comm.sendCommand(new ListBreakPointsHandler(*this, true));
+		reloadBreakpoints(true);
 	}
 	// update recent
 	if (session.existsAsFile()) {
@@ -1178,7 +1143,8 @@ void DebuggerForm::toggleBreakpoint(int addr)
 		cmd = Breakpoints::createSetCommand(Breakpoints::BREAKPOINT, addr, ps, ss, seg);
 	}
 	comm.sendCommand(new SimpleCommand(cmd));
-	comm.sendCommand(new ListBreakPointsHandler(*this));
+	// Get results from command above
+	reloadBreakpoints();
 }
 
 void DebuggerForm::addBreakpoint()
@@ -1195,7 +1161,8 @@ void DebuggerForm::addBreakpoint()
 				bpd.type(), bpd.address(), bpd.slot(), bpd.subslot(), bpd.segment(),
 				bpd.addressEndRange(), bpd.condition());
 			comm.sendCommand(new SimpleCommand(cmd));
-			comm.sendCommand(new ListBreakPointsHandler(*this));
+			// Get results of command above
+			reloadBreakpoints();
 		}
 	}
 }
@@ -1506,5 +1473,32 @@ void DebuggerForm::addressSlot(int addr, qint8& ps, qint8& ss, qint16& segment)
 		int q = 2*p + ((addr & 0x2000) >> 13);
 		if (memLayout.romBlock[q] >= 0)
 			segment = memLayout.romBlock[q];
+	}
+}
+
+void DebuggerForm::reloadBreakpoints(bool merge)
+{
+	auto command = new Command("debug_list_all_breaks",
+	                           [this, merge](const QString& message){ processBreakpoints(message, merge); });
+	comm.sendCommand(command);
+}
+
+void DebuggerForm::processBreakpoints(const QString& message, bool merge)
+{
+	if (merge) {
+		QString bps = session.breakpoints().mergeBreakpoints(message);
+		if (!bps.isEmpty()) {
+			comm.sendCommand(new SimpleCommand(bps));
+			reloadBreakpoints(false);
+		} else {
+			disasmView->update();
+			session.sessionModified();
+			updateWindowTitle();
+		}
+	} else {
+		session.breakpoints().setBreakpoints(message);
+		disasmView->update();
+		session.sessionModified();
+		updateWindowTitle();
 	}
 }

--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -1141,7 +1141,7 @@ void DebuggerForm::toggleBreakpoint(int addr)
 		qint16 seg;
 		addressSlot(addr, ps, ss, seg);
 		// create command
-		cmd = Breakpoints::createSetCommand(Breakpoints::BREAKPOINT, addr, ps, ss, seg);
+		cmd = Breakpoints::createSetCommand(Breakpoint::BREAKPOINT, addr, ps, ss, seg);
 	}
 	comm.sendCommand(new SimpleCommand(cmd));
 	// Get results from command above
@@ -1155,7 +1155,7 @@ void DebuggerForm::addBreakpoint()
 	qint8 ps, ss;
 	qint16 seg;
 	addressSlot(addr, ps, ss, seg);
-	bpd.setData(Breakpoints::BREAKPOINT, addr, ps, ss, seg);
+	bpd.setData(Breakpoint::BREAKPOINT, addr, ps, ss, seg);
 	if (bpd.exec()) {
 		if (bpd.address() >= 0) {
 			QString cmd = Breakpoints::createSetCommand(

--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -10,6 +10,7 @@
 #include "FlagsViewer.h"
 #include "StackViewer.h"
 #include "SlotViewer.h"
+#include "BreakpointViewer.h"
 #include "CommClient.h"
 #include "ConnectDialog.h"
 #include "SymbolManager.h"
@@ -227,6 +228,10 @@ void DebuggerForm::createActions()
 	viewRegistersAction->setStatusTip(tr("Toggle the cpu registers display"));
 	viewRegistersAction->setCheckable(true);
 
+	viewBreakpointsAction = new QAction(tr("Debug &List"), this);
+	viewBreakpointsAction->setStatusTip(tr("Toggle the breakpoints/watchpoints display"));
+	viewBreakpointsAction->setCheckable(true);
+
 	viewFlagsAction = new QAction(tr("CPU &Flags"), this);
 	viewFlagsAction->setStatusTip(tr("Toggle the cpu flags display"));
 	viewFlagsAction->setCheckable(true);
@@ -332,6 +337,7 @@ void DebuggerForm::createActions()
 	connect(systemPreferencesAction, SIGNAL(triggered()), this, SLOT(systemPreferences()));
 	connect(searchGotoAction, SIGNAL(triggered()), this, SLOT(searchGoto()));
 	connect(viewRegistersAction, SIGNAL(triggered()), this, SLOT(toggleRegisterDisplay()));
+	connect(viewBreakpointsAction, SIGNAL(triggered()), this, SLOT(toggleBreakpointsDisplay()));
 	connect(viewFlagsAction, SIGNAL(triggered()), this, SLOT(toggleFlagsDisplay()));
 	connect(viewStackAction, SIGNAL(triggered()), this, SLOT(toggleStackDisplay()));
 	connect(viewSlotsAction, SIGNAL(triggered()), this, SLOT(toggleSlotsDisplay()));
@@ -395,6 +401,7 @@ void DebuggerForm::createMenus()
 	viewMenu->addAction(viewStackAction);
 	viewMenu->addAction(viewSlotsAction);
 	viewMenu->addAction(viewMemoryAction);
+	viewMenu->addAction(viewBreakpointsAction);
 	viewVDPDialogsMenu = viewMenu->addMenu("VDP");
 	viewMenu->addSeparator();
 	viewFloatingWidgetsMenu = viewMenu->addMenu("Floating widgets:");
@@ -528,7 +535,6 @@ void DebuggerForm::createForm()
 	        mainMemoryView, SLOT(registerChanged(int,int)));
 	mainMemoryView->setRegsView(regsView);
 
-
 	// create flags viewer
 	flagsView = new FlagsViewer();
 	dw = new DockableWidget(dockMan);
@@ -567,9 +573,27 @@ void DebuggerForm::createForm()
 	dw->setClosable(true);
 	connect(dw, SIGNAL(visibilityChanged(DockableWidget*)),
 	        this, SLOT(dockWidgetVisibilityChanged(DockableWidget*)));
-	connect(this, SIGNAL(connected()),
-	        slotView, SLOT(refresh()));
+	connect(this, &DebuggerForm::connected, slotView, &SlotViewer::refresh);
 	connect(this, &DebuggerForm::breakStateEntered, slotView, &SlotViewer::refresh);
+
+	// create breakpoints viewer
+	bpView = new BreakpointViewer(this);
+	connect(bpView, &BreakpointViewer::contentsUpdated, this, &DebuggerForm::reloadBreakpoints);
+	connect(this, &DebuggerForm::breakpointsUpdated, bpView, &BreakpointViewer::sync);
+	dw = new DockableWidget(dockMan);
+	dw->setWidget(bpView);
+	dw->setTitle(tr("Debug list"));
+	dw->setId("DEBUG");
+	dw->setFloating(false);
+	dw->setDestroyable(false);
+	dw->setMovable(true);
+	dw->setClosable(true);
+	connect(dw, &DockableWidget::visibilityChanged, this,
+		&DebuggerForm::dockWidgetVisibilityChanged);
+	connect(this, &DebuggerForm::runStateEntered, bpView, &BreakpointViewer::setRunState);
+	connect(this, &DebuggerForm::breakStateEntered, bpView, &BreakpointViewer::setBreakState);
+	// TODO replace sync by new function that only repaint bp/wp row
+	connect(slotView, &SlotViewer::slotsUpdated, bpView, &BreakpointViewer::sync);
 
 	// restore layout
 	restoreGeometry(Settings::get().value("Layout/WindowGeometry", saveGeometry()).toByteArray());
@@ -583,15 +607,18 @@ void DebuggerForm::createForm()
 		list.append("FLAGS D V R 0 -1 -1");
 		int regW  = dockMan.findDockableWidget("REGISTERS")->sizeHint().width();
 		int regH  = dockMan.findDockableWidget("REGISTERS")->sizeHint().height();
+		list.append(QString("SLOTS D V R 0 -1 %1").arg(regH));
 		int codeW = dockMan.findDockableWidget("CODEVIEW")->sizeHint().width();
 		int codeH = dockMan.findDockableWidget("CODEVIEW")->sizeHint().height();
 		int flagW = dockMan.findDockableWidget("FLAGS")->sizeHint().width();
 		int slotW = dockMan.findDockableWidget("SLOTS")->sizeHint().width();
-		list.append(QString("SLOTS D V R 0 -1 %1").arg(regH));
 		list.append(QString("STACK D V R 0 -1 %1").arg(codeH));
 		list.append(QString("MEMORY D V B %1 %2 %3").arg(codeW)
 		                                             .arg(regW + flagW + slotW)
 		                                             .arg(codeH - regH));
+		int stackW = dockMan.findDockableWidget("STACK")->sizeHint().width();
+		list.append(QString("DEBUG D V B %1 %2 -1").arg(codeW)
+		                                             .arg(regW + flagW + slotW + stackW));
 	}
 
 	// add widgets
@@ -634,7 +661,6 @@ void DebuggerForm::createForm()
 	        stackView,  SLOT(setStackPointer(quint16)));
 	connect(disasmView, SIGNAL(breakpointToggled(int)),
 	                    SLOT(toggleBreakpoint(int)));
-
 	connect(&comm, SIGNAL(connectionReady()),
 	        SLOT(initConnection()));
 	connect(&comm, SIGNAL(updateParsed(const QString&, const QString&, const QString&)),
@@ -648,6 +674,7 @@ void DebuggerForm::createForm()
 	session.breakpoints().setMemoryLayout(&memLayout);
 	mainMemory = new unsigned char[65536 + 4];
 	memset(mainMemory, 0, 65536 + 4);
+	bpView->setBreakpoints(&session.breakpoints());
 	disasmView->setMemory(mainMemory);
 	disasmView->setBreakpoints(&session.breakpoints());
 	disasmView->setMemoryLayout(&memLayout);
@@ -1174,6 +1201,11 @@ void DebuggerForm::showAbout()
 		this, "openMSX Debugger", QString(Version::full().c_str()));
 }
 
+void DebuggerForm::toggleBreakpointsDisplay()
+{
+	toggleView(qobject_cast<DockableWidget*>(bpView->parentWidget()));
+}
+
 void DebuggerForm::toggleRegisterDisplay()
 {
 	toggleView(qobject_cast<DockableWidget*>(regsView->parentWidget()));
@@ -1384,6 +1416,7 @@ void DebuggerForm::updateViewMenu()
 	viewStackAction->setChecked(stackView->isVisible());
 	viewSlotsAction->setChecked(slotView->isVisible());
 	viewMemoryAction->setChecked(mainMemoryView->isVisible());
+	viewBreakpointsAction->setChecked(bpView->isVisible());
 }
 
 void DebuggerForm::updateVDPViewMenu()

--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -569,8 +569,7 @@ void DebuggerForm::createForm()
 	        this, SLOT(dockWidgetVisibilityChanged(DockableWidget*)));
 	connect(this, SIGNAL(connected()),
 	        slotView, SLOT(refresh()));
-	connect(this, SIGNAL(breakStateEntered()),
-	        slotView, SLOT(refresh()));
+	connect(this, &DebuggerForm::breakStateEntered, slotView, &SlotViewer::refresh);
 
 	// restore layout
 	restoreGeometry(Settings::get().value("Layout/WindowGeometry", saveGeometry()).toByteArray());
@@ -918,6 +917,7 @@ void DebuggerForm::updateData()
 
 void DebuggerForm::setBreakMode()
 {
+	emit breakStateEntered();
 	executeBreakAction->setEnabled(false);
 	executeRunAction->setEnabled(true);
 	executeStepAction->setEnabled(true);
@@ -929,6 +929,7 @@ void DebuggerForm::setBreakMode()
 
 void DebuggerForm::setRunMode()
 {
+	emit runStateEntered();
 	executeBreakAction->setEnabled(true);
 	executeRunAction->setEnabled(false);
 	executeStepAction->setEnabled(false);
@@ -1494,9 +1495,11 @@ void DebuggerForm::processBreakpoints(const QString& message, bool merge)
 			disasmView->update();
 			session.sessionModified();
 			updateWindowTitle();
+			emit breakpointsUpdated();
 		}
 	} else {
 		session.breakpoints().setBreakpoints(message);
+		emit breakpointsUpdated();
 		disasmView->update();
 		session.sessionModified();
 		updateWindowTitle();

--- a/src/DebuggerForm.h
+++ b/src/DebuggerForm.h
@@ -23,7 +23,7 @@ class VDPCommandRegViewer;
 
 class DebuggerForm : public QMainWindow
 {
-	Q_OBJECT;
+	Q_OBJECT
 public:
 	DebuggerForm(QWidget* parent = nullptr);
 	~DebuggerForm() override;

--- a/src/DebuggerForm.h
+++ b/src/DebuggerForm.h
@@ -30,6 +30,7 @@ public:
 
 public slots:
 	void showAbout();
+	void reloadBreakpoints(bool merge = false);
 
 private:
 	void closeEvent(QCloseEvent* e) override;
@@ -188,6 +189,7 @@ private slots:
 	void updateWindowTitle();
 	void symbolFileChanged();
 	void showFloatingWidget();
+	void processBreakpoints(const QString& message, bool merge = false);
 
 	friend class QueryPauseHandler;
 	friend class QueryBreakedHandler;

--- a/src/DebuggerForm.h
+++ b/src/DebuggerForm.h
@@ -193,7 +193,8 @@ private slots:
 	void updateWindowTitle();
 	void symbolFileChanged();
 	void showFloatingWidget();
-	void processBreakpoints(const QString& message, bool merge = false);
+	void processBreakpoints(const QString& message);
+	void processMerge(const QString& message);
 
 	friend class QueryPauseHandler;
 	friend class QueryBreakedHandler;

--- a/src/DebuggerForm.h
+++ b/src/DebuggerForm.h
@@ -202,7 +202,9 @@ signals:
 	void connected();
 	void settingsChanged();
 	void symbolsChanged();
+	void runStateEntered();
 	void breakStateEntered();
+	void breakpointsUpdated();
 	void debuggablesChanged(const QMap<QString, int>& list);
 };
 

--- a/src/DebuggerForm.h
+++ b/src/DebuggerForm.h
@@ -20,6 +20,7 @@ class QToolBar;
 class VDPStatusRegViewer;
 class VDPRegViewer;
 class VDPCommandRegViewer;
+class BreakpointViewer;
 
 class DebuggerForm : public QMainWindow
 {
@@ -94,6 +95,7 @@ private:
 	QAction* viewStackAction;
 	QAction* viewSlotsAction;
 	QAction* viewMemoryAction;
+	QAction* viewBreakpointsAction;
 	QAction* viewDebuggableViewerAction;
 
 	QAction* viewBitMappedAction;
@@ -129,6 +131,7 @@ private:
 	VDPStatusRegViewer* VDPStatusRegView;
 	VDPRegViewer* VDPRegView;
 	VDPCommandRegViewer* VDPCommandRegView;
+	BreakpointViewer* bpView;
 
 	CommClient& comm;
 	DebugSession session;
@@ -153,6 +156,7 @@ private slots:
 	void systemSymbolManager();
 	void systemPreferences();
 	void searchGoto();
+	void toggleBreakpointsDisplay();
 	void toggleRegisterDisplay();
 	void toggleFlagsDisplay();
 	void toggleStackDisplay();

--- a/src/DisasmViewer.h
+++ b/src/DisasmViewer.h
@@ -13,7 +13,7 @@ struct MemoryLayout;
 
 class DisasmViewer : public QFrame
 {
-	Q_OBJECT;
+	Q_OBJECT
 public:
 	DisasmViewer(QWidget* parent = nullptr);
 

--- a/src/DockableWidget.cpp
+++ b/src/DockableWidget.cpp
@@ -23,6 +23,7 @@ DockableWidget::DockableWidget(DockManager& manager, QWidget* parent)
 	destroyable = true;
 	dragging = false;
 	setAttribute(Qt::WA_DeleteOnClose, true);
+	setWindowFlags(Qt::FramelessWindowHint | Qt::Tool);
 
 	titleLabel = new QLabel();
 	closeButton = new QToolButton();
@@ -128,7 +129,6 @@ void DockableWidget::setFloating(bool enable, bool showNow)
 	if (floating == enable) return;
 
 	floating = enable;
-	setWindowFlags(floating ? Qt::FramelessWindowHint | Qt::Tool : Qt::Widget);
 
 	if (mainWidget->sizePolicy().horizontalPolicy() != QSizePolicy::Fixed &&
 			mainWidget->sizePolicy().verticalPolicy() != QSizePolicy::Fixed) {

--- a/src/DockableWidget.h
+++ b/src/DockableWidget.h
@@ -14,7 +14,7 @@ class QStatusBar;
 
 class DockableWidget : public QWidget
 {
-	Q_OBJECT;
+	Q_OBJECT
 public:
 	DockableWidget(DockManager& manager, QWidget* parent = nullptr);
 	~DockableWidget() override;

--- a/src/DockableWidgetArea.h
+++ b/src/DockableWidgetArea.h
@@ -9,7 +9,7 @@ class QPaintEvent;
 
 class DockableWidgetArea : public QWidget
 {
-	Q_OBJECT;
+	Q_OBJECT
 public:
 	DockableWidgetArea(QWidget* parent = nullptr);
 

--- a/src/DockableWidgetLayout.h
+++ b/src/DockableWidgetLayout.h
@@ -10,7 +10,7 @@ class QStringList;
 
 class DockableWidgetLayout : public QLayout
 {
-	Q_OBJECT;
+	Q_OBJECT
 public:
 	enum DockSide { TOP, LEFT, RIGHT, BOTTOM };
 

--- a/src/FlagsViewer.h
+++ b/src/FlagsViewer.h
@@ -10,7 +10,7 @@ class QString;
 
 class FlagsViewer : public QFrame
 {
-	Q_OBJECT;
+	Q_OBJECT
 public:
 	FlagsViewer(QWidget* parent = nullptr);
 

--- a/src/ScopedAssign.h
+++ b/src/ScopedAssign.h
@@ -1,0 +1,25 @@
+#ifndef SCOPEDASSIGN_HH
+#define SCOPEDASSIGN_HH
+
+/** Assign new value to some variable and restore the original value
+  * when this object goes out of scope.
+  */
+template<typename T> class ScopedAssign
+{
+public:
+	[[nodiscard]] ScopedAssign(T& var_, T newValue)
+		: var(var_)
+	{
+		oldValue = var;
+		var = newValue;
+	}
+	~ScopedAssign()
+	{
+		var = oldValue;
+	}
+private:
+	T& var;
+	T oldValue;
+};
+
+#endif

--- a/src/SlotViewer.cpp
+++ b/src/SlotViewer.cpp
@@ -18,7 +18,7 @@ public:
 
 	void replyOk(const QString& message) override
 	{
-		viewer.slotsUpdated(message);
+		viewer.updateSlots(message);
 		delete this;
 	}
 private:
@@ -193,7 +193,7 @@ void SlotViewer::setMemoryLayout(MemoryLayout* ml)
 	memLayout = ml;
 }
 
-void SlotViewer::slotsUpdated(const QString& message)
+void SlotViewer::updateSlots(const QString& message)
 {
 	QStringList lines = message.split('\n');
 
@@ -228,4 +228,5 @@ void SlotViewer::slotsUpdated(const QString& message)
 			memLayout->romBlock[i] = lines[l].toInt();
 	}
 	update();
+	emit slotsUpdated();
 }

--- a/src/SlotViewer.h
+++ b/src/SlotViewer.h
@@ -13,7 +13,7 @@ public:
 	SlotViewer(QWidget* parent = nullptr);
 
 	void setMemoryLayout(MemoryLayout* ml);
-	void slotsUpdated(const QString& message);
+	void updateSlots(const QString& message);
 
 	QSize sizeHint() const override;
 
@@ -32,6 +32,9 @@ private:
 
 	bool slotsChanged[4];
 	bool segmentsChanged[4];
+
+signals:
+	void slotsUpdated();
 };
 
 #endif // SLOTVIEWER_H

--- a/src/SlotViewer.h
+++ b/src/SlotViewer.h
@@ -8,7 +8,7 @@ class QString;
 
 class SlotViewer : public QFrame
 {
-	Q_OBJECT;
+	Q_OBJECT
 public:
 	SlotViewer(QWidget* parent = nullptr);
 

--- a/src/StackViewer.h
+++ b/src/StackViewer.h
@@ -9,7 +9,7 @@ class QPaintEvent;
 
 class StackViewer : public QFrame
 {
-	Q_OBJECT;
+	Q_OBJECT
 public:
 	StackViewer(QWidget* parent = nullptr);
 

--- a/src/node.mk
+++ b/src/node.mk
@@ -11,7 +11,8 @@ MOC_SRC_HDR:= \
 	DebugSession MainMemoryViewer BitMapViewer VramBitMappedView \
 	VDPDataStore VDPStatusRegViewer VDPRegViewer InteractiveLabel \
 	InteractiveButton VDPCommandRegViewer GotoDialog SymbolTable \
-	TileViewer VramTiledView PaletteDialog VramSpriteView SpriteViewer
+	TileViewer VramTiledView PaletteDialog VramSpriteView SpriteViewer \
+	BreakpointViewer
 
 SRC_HDR:= \
 	DockManager Dasm DasmTables DebuggerData SymbolTable Convert Version \
@@ -23,6 +24,6 @@ SRC_ONLY:= \
 UI:= \
 	ConnectDialog SymbolManager PreferencesDialog BreakpointDialog \
 	BitMapViewer VDPStatusRegisters VDPRegistersExplained VDPCommandRegisters \
-	GotoDialog TileViewer PaletteDialog SpriteViewer
+	GotoDialog TileViewer PaletteDialog SpriteViewer BreakpointViewer
 
 include build/node-end.mk


### PR DESCRIPTION
A table of breakpoints that is separated from DisasmView makes breakpoints easier to manage.

![image](https://user-images.githubusercontent.com/7815819/156891239-3e1820e7-a699-4984-9d93-fce992747338.png)

TODO:
* ~fix update issues~
* ~fix widget style properties~
* ~primary field~
* ~secondary field~
* ~join primary and secondary fields~
* ~segment field~
* ~watchpoint table~
