### PR TITLE
MemoryLayout constructor changes

### DIFF
--- a/src/BreakpointDialog.cpp
+++ b/src/BreakpointDialog.cpp
@@ -79,8 +79,8 @@ QString BreakpointDialog::condition()
 	return (cbCondition->checkState() == Qt::Checked) ? txtCondition->toPlainText() : "";
 }
 
-void BreakpointDialog::setData(Breakpoints::Type type, int address, int ps, int ss, int segment,
-                               int addressEnd, QString condition)
+void BreakpointDialog::setData(Breakpoints::Type type, int address, qint8 ps, qint8 ss,
+                               qint16 segment, int addressEnd, QString condition)
 {
 	// set type
 	cmbxType->setCurrentIndex(int(type));
@@ -94,19 +94,19 @@ void BreakpointDialog::setData(Breakpoints::Type type, int address, int ps, int 
 
 	// primary slot
 	if (cmbxSlot->isEnabled() && ps >= 0) {
-		cmbxSlot->setCurrentIndex(ps+1);
+		cmbxSlot->setCurrentIndex(ps + 1);
 		slotChanged(cmbxSlot->currentIndex());
 	}
 
 	// secondary slot
 	if (cmbxSubslot->isEnabled() && ss >= 0) {
-		cmbxSubslot->setCurrentIndex(ss+1);
+		cmbxSubslot->setCurrentIndex(ss + 1);
 		subslotChanged(cmbxSubslot->currentIndex());
 	}
 
 	// segment
 	if (cmbxSegment->isEnabled() && segment >= 0) {
-		cmbxSegment->setCurrentIndex(segment+1);
+		cmbxSegment->setCurrentIndex(segment + 1);
 	}
 
 	// end address

--- a/src/BreakpointDialog.h
+++ b/src/BreakpointDialog.h
@@ -26,7 +26,7 @@ public:
 	QString condition();
 
 	void setData(Breakpoints::Type type, int address = -1,
-	             int ps = -1, int ss = -1, int segment = -1,
+	             qint8 ps = -1, qint8 ss = -1, qint16 segment = -1,
 	             int addressEnd = -1, QString condition = QString());
 
 private:

--- a/src/DebuggerData.cpp
+++ b/src/DebuggerData.cpp
@@ -8,8 +8,8 @@
 MemoryLayout::MemoryLayout()
 {
 	for (int p = 0; p < 4; ++p) {
-		primarySlot[p] = '0';
-		secondarySlot[p] = 'X';
+		primarySlot[p] = 0;
+		secondarySlot[p] = -1;
 		mapperSegment[p] = 0;
 		isSubslotted[p] = false;
 		for (int q = 0; q < 4; ++q) {
@@ -80,7 +80,7 @@ void Breakpoints::setMemoryLayout(MemoryLayout* ml)
 	memLayout = ml;
 }
 
-QString Breakpoints::createSetCommand(Type type, int address, char ps, char ss, int segment,
+QString Breakpoints::createSetCommand(Type type, int address, qint8 ps, qint8 ss, qint16 segment,
                                       int endRange, QString condition)
 {
 	QString cmd("debug %1 %2 %3");
@@ -99,9 +99,9 @@ QString Breakpoints::createSetCommand(Type type, int address, char ps, char ss, 
 		condition = condition.simplified();
 		cond = QString("{ [ %1_in_slot %2 %3 %4 ] %5}")
 		       .arg(type == WATCHPOINT_MEMREAD || type == WATCHPOINT_MEMWRITE ? "watch" : "pc")
-		       .arg(ps==-1 ? 'X' : char('0'+ps))
-		       .arg(ss==-1 ? 'X' : char('0'+ss))
-		       .arg(segment==-1 ? QString('X') : QString::number(segment))
+		       .arg(ps == -1 ? 'X' : char('0' + ps))
+		       .arg(ss == -1 ? 'X' : char('0' + ss))
+		       .arg(segment == -1 ? QString('X') : QString::number(segment))
 		       .arg(condition.isEmpty() ? QString() : QString("&& ( %1 ) ").arg(condition));
 	}
 

--- a/src/DebuggerData.h
+++ b/src/DebuggerData.h
@@ -44,7 +44,7 @@ public:
 	int findNextBreakpoint();
 
 	static QString createSetCommand(Type type, int address,
-	                                char ps = -1, char ss = -1, int segment = -1,
+	                                qint8 ps = -1, qint8 ss = -1, qint16 segment = -1,
 	                                int endRange = -1, QString condition = QString());
 	static QString createRemoveCommand(const QString& id);
 
@@ -56,8 +56,8 @@ private:
 		// end for watchpoint region
 		quint16 regionEnd;
 		// gui specific condition variables
-		char ps;
-		char ss;
+		qint8 ps;
+		qint8 ss;
 		qint16 segment;
 		// general condition
 		QString condition;

--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -1170,7 +1170,8 @@ void DebuggerForm::toggleBreakpoint(int addr)
 		cmd = Breakpoints::createRemoveCommand(id);
 	} else {
 		// get slot
-		int ps, ss, seg;
+		qint8 ps, ss;
+		qint16 seg;
 		addressSlot(addr, ps, ss, seg);
 		// create command
 		cmd = Breakpoints::createSetCommand(Breakpoints::BREAKPOINT, addr, ps, ss, seg);
@@ -1183,7 +1184,8 @@ void DebuggerForm::addBreakpoint()
 {
 	BreakpointDialog bpd(memLayout, &session, this);
 	int addr = disasmView->cursorAddress();
-	int ps, ss, seg;
+	qint8 ps, ss;
+	qint16 seg;
 	addressSlot(addr, ps, ss, seg);
 	bpd.setData(Breakpoints::BREAKPOINT, addr, ps, ss, seg);
 	if (bpd.exec()) {
@@ -1490,12 +1492,11 @@ void DebuggerForm::symbolFileChanged()
 		session.symbolTable().reloadFiles();
 }
 
-void DebuggerForm::addressSlot(int addr, int& ps, int& ss, int& segment)
+void DebuggerForm::addressSlot(int addr, qint8& ps, qint8& ss, qint16& segment)
 {
 	int p = (addr & 0xC000) >> 14;
 	ps = memLayout.primarySlot[p];
-	// figure out secondary slot
-	ss = memLayout.isSubslotted[ps] ? memLayout.secondarySlot[p] : -1;
+	ss = memLayout.secondarySlot[p];
 	// figure out (rom) mapper segment
 	segment = -1;
 	if (memLayout.mapperSize[ps][ss==-1 ? 0 : ss] > 0)

--- a/src/DebuggerForm.h
+++ b/src/DebuggerForm.h
@@ -54,7 +54,7 @@ private:
 
 	void refreshBreakpoints();
 
-	void addressSlot(int addr, int& ps, int& ss, int& segment);
+	void addressSlot(int addr, qint8& ps, qint8& ss, qint16& segment);
 
 	QMenu* fileMenu;
 	QMenu* systemMenu;

--- a/src/HexViewer.cpp
+++ b/src/HexViewer.cpp
@@ -701,7 +701,7 @@ bool HexViewer::event(QEvent* e)
 			unsigned wd = chr;
 			wd += 256 * hexData[address + 1];
 			text += QString("\n\nWord: %1").arg(QString("%1").arg(wd, 4, 16, QChar('0')).toUpper());
-			text += QString("\nBinary: %1 %1 %1 %1")
+			text += QString("\nBinary: %1 %2 %3 %4")
 				.arg((wd & 0xF000) >> 12, 4, 2, QChar('0'))
 				.arg((wd & 0x0F00) >>  8, 4, 2, QChar('0'))
 				.arg((wd & 0x00F0) >>  4, 4, 2, QChar('0'))

--- a/src/SlotViewer.cpp
+++ b/src/SlotViewer.cpp
@@ -202,7 +202,8 @@ void SlotViewer::slotsUpdated(const QString& message)
 		slotsChanged[p] = (memLayout->primarySlot  [p] != lines[p * 2][0].toLatin1()-'0') ||
 		                  (memLayout->secondarySlot[p] != lines[p * 2][1].toLatin1()-'0' && memLayout->isSubslotted[p]);
 		memLayout->primarySlot  [p] = lines[p * 2][0].toLatin1()-'0';
-		memLayout->secondarySlot[p] = lines[p * 2][1].toLatin1()-'0';
+		memLayout->secondarySlot[p] = (lines[p * 2][1]) == 'X'
+			? -1 : lines[p * 2][1].toLatin1() - '0';
 		segmentsChanged[p] = memLayout->mapperSegment[p] !=
 		                     lines[p * 2 + 1].toInt();
 		memLayout->mapperSegment[p] = lines[p * 2 + 1].toInt();


### PR DESCRIPTION
`MemoryLayout` constructor has code such as:
```
        primarySlot[p] = '0';
        secondarySlot[p] = 'X';
```
which tells me that they store ASCII code. But then, everywhere else `MemoryLayout::{primary, secondary}Slot` are treated as byte-sized integers. This is confusing and error prone. I am surprised it didn't burst into flames when I found it, since there are loads of code that do this:
```
        if (bp.ps == -1 || bp.ps == memLayout->primarySlot[page])
...
        if (bp.ss == -1 || bp.ss == memLayout->secondarySlot[page])
```
but then I found later on that `SlotViewer::slotsUpdated()` sets `MemoryLayout::{primary, secondary}Slot` as byte-sized integers as well after the first debug step:
```
        memLayout->primarySlot  [p] = lines[p * 2][0].toLatin1()-'0';
        memLayout->secondarySlot[p] = lines[p * 2][1].toLatin1()-'0';
```
So this PR changes MemoryLayout constructor to use the same data representation. And it also replaces `char` by `qint8` to emphasize this distinction in other places.