### PR TITLE
SIGABRT received because of dead pointer reference

### DIFF
--- a/src/DisasmViewer.cpp
+++ b/src/DisasmViewer.cpp
@@ -420,19 +420,20 @@ void DisasmViewer::memoryUpdated(CommMemoryRequest* req)
 		break;
 	case OnDemand:
 		// Only change the topline if we're out of bounds
-		if (cursorAddr < disasmLines[disasmTopLine].addr ||
-            cursorAddr > disasmLines[disasmTopLine + visibleLines].addr) {
+		if (cursorAddr < disasmLines[disasmTopLine].addr
+		    || cursorAddr > disasmLines[disasmTopLine + visibleLines].addr) {
 			disasmTopLine = findDisasmLine(cursorAddr);
 		}
 		break;
-    default:
-        disasmTopLine = reqDisasmTopLine;
+	default:
+		disasmTopLine = reqDisasmTopLine;
 	}
 
 	disasmTopLine = std::max(disasmTopLine, 0);
 	disasmTopLine = std::min(disasmTopLine,
 	                         int(disasmLines.size()) - visibleLines);
 
+	int method = req->method;
 	updateCancelled(req);
 
 	// sync the scrollbar with the actual address reached
@@ -445,7 +446,7 @@ void DisasmViewer::memoryUpdated(CommMemoryRequest* req)
 		           this, SLOT(scrollBarChanged(int)));
 		// set the line
 		setAddress(disasmLines[disasmTopLine].addr,
-		           disasmLines[disasmTopLine].infoLine, req->method);
+		           disasmLines[disasmTopLine].infoLine, method);
 		update();
 	}
 }


### PR DESCRIPTION
In line 436, `memoryUpdated()` calls `updateCanceled(req)`:
```
        updateCancelled(req);

        // sync the scrollbar with the actual address reached
        if (!waitingForData) {
```
But `updateCancelled()` deletes `req`. So, referencing `req->method` later on line 459:
```
                setAddress(disasmLines[disasmTopLine].addr,
                           disasmLines[disasmTopLine].infoLine, req->method);
```
is a reference to a dead pointer. So `req->method` now has an incorrect value and it triggers the `assert()`. This patch fixes the access violation, but I am afraid this is not all. There is an infinite loop situation going on that slows down the debugger for no good reason. When the debugger connects, it loops infinitely because

* `DisasmViewer::refresh()` calls `DisasmViewer::setAddress()`;
* `DisasmViewer::setAddress()` creates and sends `CommMemoryRequest` to the emulator;
* `CommMemoryRequest::replyOk()` calls `DisasmViewer::memoryUpdated()` when finished;
* `DisasmViewer::memoryUpdated()` calls `DisasmViewer::setAddress()` closing the loop.

It's not so bad because the infinite loop is maintained by signal/slot event looping, so it doesn't hijack the CPU completely. This happens now because `memoryUpdated()` always invoke `setAddress()` with the same `OnDemand` value it received. It used to call `setAddress()` next time with `Top` by default, which would break the cycle it seems. If you move the disassembler window with the wheel the infinite loop stops, but it may start again if you press any of the step/go/break buttons.




