### PR TITLE
no tools left behind... the main window

### DIFF
--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -720,6 +720,7 @@ void DebuggerForm::closeEvent(QCloseEvent* e)
 			     .arg(widget->width()).arg(widget->height());
 			layoutList.append(s);
 		}
+		widget->hide();
 	}
 	Settings::get().setValue("Layout/WidgetLayout", layoutList);
 

--- a/src/DockableWidget.cpp
+++ b/src/DockableWidget.cpp
@@ -137,6 +137,8 @@ void DockableWidget::setFloating(bool enable, bool showNow)
 	}
 
 	if (floating && showNow) {
+		// force widget to never get behind main window
+		setWindowFlags(Qt::FramelessWindowHint | Qt::Tool);
 		show();
 	}
 }


### PR DESCRIPTION
Definitive fix for tools getting behind main window, specially if they were created first in a docked state and later became floaters. This is practically a part 2 of pull request #83.

Also: some tools were not closing when main window was closed because they are set to not destruct and `event->ignore()`'ing close events, which interrupts the process of application shutdown and let them in a weird zombie state.

So now we `hide()` all of them individually when closing the main window. That seems to do the trick.