### PR TITLE
BreakpointViewer doesn't reload breakpoints anymore

### DIFF
--- a/src/BreakpointViewer.ui
+++ b/src/BreakpointViewer.ui
@@ -75,7 +75,7 @@
        <number>120</number>
       </attribute>
       <attribute name="horizontalHeaderStretchLastSection">
-       <bool>false</bool>
+       <bool>true</bool>
       </attribute>
       <attribute name="verticalHeaderVisible">
        <bool>false</bool>
@@ -197,7 +197,7 @@
        <number>120</number>
       </attribute>
       <attribute name="horizontalHeaderStretchLastSection">
-       <bool>false</bool>
+       <bool>true</bool>
       </attribute>
       <attribute name="verticalHeaderVisible">
        <bool>false</bool>
@@ -319,7 +319,7 @@
        <number>120</number>
       </attribute>
       <attribute name="horizontalHeaderStretchLastSection">
-       <bool>false</bool>
+       <bool>true</bool>
       </attribute>
       <attribute name="verticalHeaderVisible">
        <bool>false</bool>

--- a/src/DebuggerData.cpp
+++ b/src/DebuggerData.cpp
@@ -127,6 +127,7 @@ QString Breakpoints::createRemoveCommand(const QString& id)
 void Breakpoints::setBreakpoints(const QString& str)
 {
 	breakpoints.clear();
+
 	QStringList bps = str.split('\n');
 	for (auto& bp : bps) {
 		if (bp.trimmed().isEmpty()) continue;
@@ -269,9 +270,9 @@ bool Breakpoints::inCurrentSlot(const Breakpoint& bp)
 void Breakpoints::insertBreakpoint(Breakpoint& bp)
 {
 	auto it = std::upper_bound(breakpoints.begin(), breakpoints.end(), bp,
-	           [](const Breakpoint& bp1, const Breakpoint& bp2) {
-	               return bp1.address < bp2.address;
-			   }
+	    [](const Breakpoint& bp1, const Breakpoint& bp2) {
+	        return bp1.address < bp2.address;
+	    }
 	);
 	breakpoints.insert(it, bp);
 }

--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -580,6 +580,7 @@ void DebuggerForm::createForm()
 	bpView = new BreakpointViewer(this);
 	connect(bpView, &BreakpointViewer::contentsUpdated, this, &DebuggerForm::reloadBreakpoints);
 	connect(this, &DebuggerForm::breakpointsUpdated, bpView, &BreakpointViewer::sync);
+
 	dw = new DockableWidget(dockMan);
 	dw->setWidget(bpView);
 	dw->setTitle(tr("Debug list"));
@@ -592,8 +593,6 @@ void DebuggerForm::createForm()
 		&DebuggerForm::dockWidgetVisibilityChanged);
 	connect(this, &DebuggerForm::runStateEntered, bpView, &BreakpointViewer::setRunState);
 	connect(this, &DebuggerForm::breakStateEntered, bpView, &BreakpointViewer::setBreakState);
-	// TODO replace sync by new function that only repaint bp/wp row
-	connect(slotView, &SlotViewer::slotsUpdated, bpView, &BreakpointViewer::sync);
 
 	// restore layout
 	restoreGeometry(Settings::get().value("Layout/WindowGeometry", saveGeometry()).toByteArray());
@@ -674,7 +673,6 @@ void DebuggerForm::createForm()
 	session.breakpoints().setMemoryLayout(&memLayout);
 	mainMemory = new unsigned char[65536 + 4];
 	memset(mainMemory, 0, 65536 + 4);
-	bpView->setBreakpoints(&session.breakpoints());
 	disasmView->setMemory(mainMemory);
 	disasmView->setBreakpoints(&session.breakpoints());
 	disasmView->setMemoryLayout(&memLayout);
@@ -682,6 +680,7 @@ void DebuggerForm::createForm()
 	mainMemoryView->setDebuggable("memory", 65536);
 	stackView->setData(mainMemory, 65536);
 	slotView->setMemoryLayout(&memLayout);
+	bpView->setBreakpoints(&session.breakpoints());
 }
 
 DebuggerForm::~DebuggerForm()


### PR DESCRIPTION
`BreakpointViewer` now stores references to Breakpoints (Breakpoint, Watchpoints and Conditions) through 3 `std::map`s of new data structure `BreakpointData` because just storing references in a hidden column in `QTableWidget` is not flexible or powerful enough. The new data structure allows `BreakpointViewer` to sync with the emulator only when reconnected and not every time a new breakpoint is created or modified, which is more efficient. Also, since the table of breakpoints is not erased every time, items will not move around without the user's consent (they will not be destroyed and recreated, but reused).

minor changes:
* renamed `processXXXX` functions to `parseXXXX` because it is a less generic name;
* hidden 6th table column stores breakpoint name (id) instead of index;
* more generic and useful `setTextField` function instead of `item->setText()`;
* message box displayed when error received from **openMSX**;
* the **debugger** now waits for **openMSX** response before performing changes;
* to avoid rows moving around, editing or adding a breakpoint now automatically turns sorting off.

This is an attempt to fix the remaining bugs on pull request #91.