### PR TITLE
crash if maximized in vertically rotated monitor

### DIFF
--- a/src/DisasmViewer.cpp
+++ b/src/DisasmViewer.cpp
@@ -405,9 +405,9 @@ void DisasmViewer::memoryUpdated(CommMemoryRequest* req)
 		break;
 	}
 
-	disasmTopLine = std::max(disasmTopLine, 0);
 	disasmTopLine = std::min(disasmTopLine,
 	                         int(disasmLines.size()) - visibleLines);
+	disasmTopLine = std::max(disasmTopLine, 0);
 
 	updateCancelled(req);
 


### PR DESCRIPTION
When the window is maximized on a vertical screen (portrait view), the value of `visibleLines` may be greater than `disasmLines.size()`, so `disasmTopLine` can become negative. Changing `std::min` and `std::max` order will make sure that `disasmTopLine` remains non negative.