### PR TITLE
Github action publishes nightly build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,15 +1,15 @@
-name: Build and release
+name: Nightly
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - master
 
 jobs:
   build:
     uses: ./.github/workflows/workflow-build.yaml
-  release:
-    name: Release project packages
+  nightly:
+    name: Release nightly packages
     runs-on: ubuntu-latest
     needs: build
     env:
@@ -47,9 +47,17 @@ jobs:
           cd ..
           mv ${{ steps.get-targets.outputs.debian_target }}/${{ steps.get-targets.outputs.debian_target }}.zip .
           mv ${{ steps.get-targets.outputs.mingw_target }}/${{ steps.get-targets.outputs.mingw_target }}.zip .
-      - name: Publish binaries as artifacts
-        uses: ncipollo/release-action@v1
+
+      - name: Create info file
+        run: |
+           echo "ref: ${GITHUB_REF}" > info.txt
+           echo "commit: ${GITHUB_SHA}" >> info.txt
+           echo "build: $(date +"%Y-%m-%dT%H:%M:%SZ")" >> info.txt
+
+      - name: Update nightly release
+        uses: eine/tip@master
         with:
-          artifacts: "*.zip"
-          body: "Build number ${{ github.run_number }}\n${{ github.event.head_commit.message }}"
+          tag: nightly
+          rm: true
           token: ${{ secrets.GITHUB_TOKEN }}
+          files: info.txt *.zip


### PR DESCRIPTION
* It's no longer necessary to be logged in to access the pre-compiled debugger;
* It is also easier to find it in the **Releases** side menu link on the GitHub repository page;
* The nightly build will not be deleted automatically after 90 days, unlike the pull request artifacts;
* Last push to the repository will automatically delete the previous nightly build and replace it with the new one;
* Failed compilations will not delete nor replace the previous nightly build;

This is how it looks like: https://github.com/pvmm/debugger/releases