### PR TITLE
using std::optional null instead of -1

### DIFF
--- a/src/BreakpointDialog.h
+++ b/src/BreakpointDialog.h
@@ -25,7 +25,7 @@ public:
 	QString condition() const;
 
 	void setData(Breakpoint::Type type, std::optional<AddressRange> range = {}, Slot slot = {},
-	             std::optional<uint8_t> segment = {}, QString condition = QString());
+	             std::optional<uint8_t> segment = {}, QString condition = {});
 
 private:
 	const MemoryLayout& memLayout;
@@ -36,7 +36,7 @@ private:
 	int conditionHeight;
 	std::unique_ptr<QCompleter> jumpCompleter;
 	std::unique_ptr<QCompleter> allCompleter;
-	std::optional<uint16_t> parseInput(QLineEdit* ed, Symbol** symbol = nullptr) const;
+	std::optional<uint16_t> parseInput(const QLineEdit& ed, Symbol** symbol = nullptr) const;
 	void enableSlots();
 	void disableSlots();
 

--- a/src/BreakpointDialog.h
+++ b/src/BreakpointDialog.h
@@ -19,27 +19,26 @@ public:
 	BreakpointDialog(const MemoryLayout& ml, DebugSession *session = nullptr, QWidget* parent = nullptr);
 
 	Breakpoint::Type type() const;
-	int address() const;
-	int addressEndRange() const;
-	int slot() const;
-	int subslot() const;
-	int segment() const;
+	std::optional<AddressRange> addressRange(Symbol** symbol = nullptr) const;
+	Slot slot() const;
+	std::optional<uint8_t> segment() const;
 	QString condition() const;
 
-	void setData(Breakpoint::Type type, int address = -1,
-	             qint8 ps = -1, qint8 ss = -1, qint16 segment = -1,
-	             int addressEnd = -1, QString condition = QString());
+	void setData(Breakpoint::Type type, std::optional<AddressRange> range = {}, Slot slot = {},
+	             std::optional<uint8_t> segment = {}, QString condition = QString());
 
 private:
 	const MemoryLayout& memLayout;
 
-	DebugSession *debugSession;
-	Symbol *currentSymbol;
+	DebugSession* debugSession;
+	Symbol* currentSymbol;
 	int idxSlot, idxSubSlot;
-	int value, valueEnd;
 	int conditionHeight;
 	std::unique_ptr<QCompleter> jumpCompleter;
 	std::unique_ptr<QCompleter> allCompleter;
+	std::optional<uint16_t> parseInput(QLineEdit* ed, Symbol** symbol = nullptr) const;
+	void enableSlots();
+	void disableSlots();
 
 private slots:
 	void addressChanged(const QString& text);

--- a/src/BreakpointViewer.h
+++ b/src/BreakpointViewer.h
@@ -11,16 +11,6 @@
 class QPaintEvent;
 class Breakpoints;
 
-struct AddressRange {
-	int start; // a single address is represented by end <= start
-	int end;   // end point is inclusive
-};
-
-struct Slot {
-    int8_t ps; // primary slot, always 0..3
-    int8_t ss; // secundary slot, 0..3 or -1 when the primary slot is not expanded
-};
-
 struct BreakpointRef {
 	enum Type { BREAKPOINT, WATCHPOINT, CONDITION, ALL } type;
 
@@ -49,10 +39,12 @@ private:
 	Breakpoints* breakpoints;
 
 	void setTextField(BreakpointRef::Type type, int row, int column, const QString& value);
-	std::optional<AddressRange> parseLocationField(int index, BreakpointRef::Type type, const QString& field,
+	std::optional<AddressRange> parseLocationField(std::optional<int> index,
+	                                               BreakpointRef::Type type,
+	                                               const QString& field,
 	                                               const QString& combo = {});
-	std::optional<Slot> parseSlotField(int index, const QString& field);
-	std::optional<qint16> parseSegmentField(int index, const QString& field);
+	Slot parseSlotField(std::optional<int> index, const QString& field);
+	std::optional<uint8_t> parseSegmentField(std::optional<int> index, const QString& field);
 	void changeTableItem(BreakpointRef::Type type, QTableWidgetItem* item);
 	void createComboBox(int row);
 	Breakpoint::Type readComboBox(int row);

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -1,57 +1,5 @@
 #include "Convert.h"
 #include "Settings.h"
-#include <QString>
-
-int stringToValue(const QString& str)
-{
-	QString s = str.trimmed();
-	int base = 10;
-
-	// find base (prefix or postfix)
-	if (s.startsWith("&") && s.size() >= 2) {
-		switch (s[1].toUpper().toLatin1()) {
-		case 'H':
-			base = 16;
-			break;
-		case 'B':
-			base = 2;
-			break;
-		case 'O':
-			base = 8;
-			break;
-		}
-		s = s.remove(0, 2);
-	} else if (s.startsWith("#") || s.startsWith("$")) {
-		base = 16;
-		s = s.remove(0, 1);
-	} else if (s.startsWith("0x")) {
-		base = 16;
-		s = s.remove(0, 2);
-	} else if (s.startsWith("%")) {
-		base = 2;
-		s = s.remove(0, 1);
-	} else if (!s.isEmpty()) {
-		switch (s.right(1)[0].toUpper().toLatin1()) {
-			case 'H':
-			case '#':
-				base = 16;
-				break;
-			case 'B':
-				base = 2;
-				break;
-			case 'O':
-				base = 8;
-				break;
-		}
-		if (base != 10) s.chop(1);
-	}
-
-	// convert value
-	bool ok;
-	int value = s.toInt(&ok, base);
-	if (!ok) return -1;
-	return value;
-}
 
 QString hexValue(int value, int width)
 {

--- a/src/Convert.h
+++ b/src/Convert.h
@@ -10,26 +10,17 @@ QString hexValue(int value, int width = 0);
 QString escapeXML(QString str);
 QString unescapeXML(QString str);
 
-template <typename T>
-std::optional<T> make_positive_optional(int value)
-{
-    return value < 0 ? std::nullopt : std::optional(value);
-}
-
 // Create optional<T> if boolean b is true.
-template <typename T, typename X>
-std::optional<T> make_if(X b, T value)
+template <typename T>
+std::optional<T> make_if(bool b, T value)
 {
-	static_assert(std::is_constructible<bool, X>::value, "X is not convertible to bool");
 	return b ? value : std::optional<T>();
 }
 
-// Create optional<T> if boolean b is true (solves implicit optional in T).
-template <typename T, typename X>
-std::optional<T> make_if(X b, std::optional<T> value)
+template <typename T>
+std::optional<T> make_positive_optional(int value)
 {
-	static_assert(std::is_constructible<bool, X>::value, "X is not convertible to bool");
-	return b ? (value ? *value : std::optional<T>()) : std::optional<T>();
+    return make_if<T>(value >= 0, T(value));
 }
 
 template <typename T>

--- a/src/Convert.h
+++ b/src/Convert.h
@@ -1,11 +1,93 @@
 #ifndef CONVERT_H
 #define CONVERT_H
 
-class QString;
+#include <QString>
+#include <cstdint>
+#include <optional>
+#include <limits>
 
-int stringToValue(const QString& str);
 QString hexValue(int value, int width = 0);
 QString escapeXML(QString str);
 QString unescapeXML(QString str);
+
+template <typename T>
+std::optional<T> make_positive_optional(int value)
+{
+    return value < 0 ? std::nullopt : std::optional(value);
+}
+
+// Create optional<T> if boolean b is true.
+template <typename T, typename X>
+std::optional<T> make_if(X b, T value)
+{
+	static_assert(std::is_constructible<bool, X>::value, "X is not convertible to bool");
+	return b ? value : std::optional<T>();
+}
+
+// Create optional<T> if boolean b is true (solves implicit optional in T).
+template <typename T, typename X>
+std::optional<T> make_if(X b, std::optional<T> value)
+{
+	static_assert(std::is_constructible<bool, X>::value, "X is not convertible to bool");
+	return b ? (value ? *value : std::optional<T>()) : std::optional<T>();
+}
+
+template <typename T>
+std::optional<T> stringToValue(const QString& str)
+{
+        QString s = str.trimmed();
+        int base = 10;
+
+        // find base (prefix or postfix)
+        if (s.startsWith("&") && s.size() >= 2) {
+                switch (s[1].toUpper().toLatin1()) {
+                case 'H':
+                        base = 16;
+                        break;
+                case 'B':
+                        base = 2;
+                        break;
+                case 'O':
+                        base = 8;
+                        break;
+                }
+                s = s.remove(0, 2);
+        } else if (s.startsWith("#") || s.startsWith("$")) {
+                base = 16;
+                s = s.remove(0, 1);
+        } else if (s.startsWith("0x")) {
+                base = 16;
+                s = s.remove(0, 2);
+        } else if (s.startsWith("%")) {
+                base = 2;
+                s = s.remove(0, 1);
+        } else if (!s.isEmpty()) {
+                switch (s.right(1)[0].toUpper().toLatin1()) {
+                        case 'H':
+                        case '#':
+                                base = 16;
+                                break;
+                        case 'B':
+                                base = 2;
+                                break;
+                        case 'O':
+                                base = 8;
+                                break;
+                }
+                if (base != 10) s.chop(1);
+        }
+
+        // convert value
+        bool ok;
+        int value = s.toInt(&ok, base);
+        if (!ok) return {};
+
+        // reject {under|over}flow
+        T max = std::numeric_limits<T>::max();
+        T min = std::numeric_limits<T>::min();
+        if (value > max || value < min) return {};
+
+        return value;
+}
 
 #endif // CONVERT_H

--- a/src/DebuggerData.cpp
+++ b/src/DebuggerData.cpp
@@ -55,15 +55,12 @@ bool Breakpoint::operator==(const Breakpoint &bp) const
 
 	// compare address
 	if (type != Breakpoint::CONDITION) {
-		if (bp.address != address) return false;
+		if (bp.range.start != range.start) return false;
 		if (type != Breakpoint::BREAKPOINT) {
-			int re1 = -1, re2 = -1;
-			if (bp.regionEnd != quint16(-1) && bp.regionEnd != bp.address) re1 = bp.regionEnd;
-			if (   regionEnd != quint16(-1) &&    regionEnd !=    address) re2 =    regionEnd;
-			if (re1 != re2) return false;
+			if (bp.range.end != range.end) return false;
 		}
 		// compare slot
-		if (bp.ps != ps || bp.ss != ss || bp.segment != segment) return false;
+		if (bp.slot.ps != slot.ps || bp.slot.ss != slot.ss || bp.segment != segment) return false;
 	}
 	// compare condition
 	return bp.condition == condition;
@@ -79,8 +76,9 @@ void Breakpoints::setMemoryLayout(MemoryLayout* ml)
 	memLayout = ml;
 }
 
-QString Breakpoints::createSetCommand(Breakpoint::Type type, quint16 address, qint8 ps, qint8 ss,
-                                      qint16 segment, int endRange, QString condition)
+QString Breakpoints::createSetCommand(Breakpoint::Type type, std::optional<AddressRange> range,
+                                      Slot slot, std::optional<uint8_t> segment,
+                                      QString condition)
 {
 	QString cmd("debug %1 %2 %3");
 	QString addr, cond;
@@ -89,21 +87,21 @@ QString Breakpoints::createSetCommand(Breakpoint::Type type, quint16 address, qi
 	if (type == Breakpoint::CONDITION) {
 		// conditions don't have an address
 		cond = QString("{%1}").arg(condition);
-	} else {
-		if ((type == Breakpoint::BREAKPOINT) || (endRange < address)) {
+	} else if (range) {
+		if (type == Breakpoint::BREAKPOINT || (range->end < range->start)) {
 			// breakpoint (these never have a range) or watchpoint without range
-			addr = QString::number(address);
+			addr = QString::number(range->start);
 		} else {
 			// some type of watchpoint (with a valid range)
-			addr = QString("{%1 %2}").arg(address).arg(endRange);
+			addr = QString("{%1 %2}").arg(range->start).arg(*range->end);
 		}
 
 		cond = QString("{ [ %1_in_slot %2 %3 %4 ] %5}")
 		       .arg(type == Breakpoint::WATCHPOINT_MEMREAD
 		         || type == Breakpoint::WATCHPOINT_MEMWRITE ? "watch" : "pc")
-		       .arg(ps == -1 ? 'X' : char('0' + ps))
-		       .arg(ss == -1 ? 'X' : char('0' + ss))
-		       .arg(segment == -1 ? QString('X') : QString::number(segment))
+		       .arg(slot.ps ? QString::number(*slot.ps) : "X")
+		       .arg(slot.ss ? QString::number(*slot.ss) : "X")
+		       .arg(segment ? QString::number(*segment) : "X")
 		       .arg(condition.isEmpty() ? QString() : QString("&& ( %1 ) ").arg(condition));
 	}
 	return cmd.arg(BreakpointSetCodes[type])
@@ -163,16 +161,28 @@ void Breakpoints::setBreakpoints(const QString& str)
 		if (newBp.type != Breakpoint::CONDITION) {
 			if (bp[p] == '{') {
 				p++;
-				newBp.address = stringToValue(getNextArgument(bp, p));
+				auto s = getNextArgument(bp, p);
+				auto start = stringToValue<uint16_t>(s);
+				if (!start) {
+					qWarning() << "watchpoint starting range invalid:" << s;
+					newBp.range = {};
+					continue;
+				}
+				newBp.range.start = *start;
 				int q = bp.indexOf('}', p);
-				newBp.regionEnd = stringToValue(bp.mid(p, q - p));
+				auto end = stringToValue<uint16_t>(bp.mid(p, q - p));
+				newBp.range.end = end;
 				p = q + 1;
 			} else {
-				newBp.address = stringToValue(getNextArgument(bp, p));
-				newBp.regionEnd = newBp.address;
+				auto s = getNextArgument(bp, p);
+				auto start = stringToValue<uint16_t>(s);
+				if (!start) {
+					qWarning() << "breakpoint starting range invalid:" << s;
+					newBp.range = {};
+				}
+				newBp.range.start = *start;
+				newBp.range.end = {};
 			}
-		} else {
-			newBp.address = -1;
 		}
 		// check and clip command (skip non-default commands)
 		int q = bp.lastIndexOf('{');
@@ -200,8 +210,7 @@ QString Breakpoints::mergeBreakpoints(const QString& str)
 		}
 		if (newit == breakpoints.end()) {
 			// create command to set this breakpoint again
-			QString cmd = createSetCommand(old.type, old.address, old.ps, old.ss, old.segment,
-			                               old.regionEnd, old.condition);
+			QString cmd = createSetCommand(old.type, old.range, old.slot, old.segment, old.condition);
 			mergeSet << cmd;
 		}
 	}
@@ -210,9 +219,8 @@ QString Breakpoints::mergeBreakpoints(const QString& str)
 
 void Breakpoints::parseCondition(Breakpoint& bp)
 {
-	bp.ps = -1;
-	bp.ss = -1;
-	bp.segment = -1;
+	bp.slot = {};
+	bp.segment = {};
 
 	// first split off braces
 	if (bp.condition[0] == '{' && bp.condition.endsWith('}')) {
@@ -220,13 +228,9 @@ void Breakpoints::parseCondition(Breakpoint& bp)
 			// check for slot argument
 			QRegExp rx(R"(^\{\s*\[\s*(pc|watch)_in_slot\s([X0123])\s([X0123])\s(X|\d{1,3})\s*\]\s*(&&\s*\((.+)\)\s*)?\}$)");
 			if (rx.indexIn(bp.condition) == 0) {
-				bool ok;
-				bp.ps = rx.cap(2).toInt(&ok);
-				if (!ok) bp.ps = -1;
-				bp.ss = rx.cap(3).toInt(&ok);
-				if (!ok) bp.ss = -1;
-				bp.segment = rx.cap(4).toInt(&ok);
-				if (!ok) bp.segment = -1;
+				bp.slot.ps = stringToValue<uint8_t>(rx.cap(2));
+				bp.slot.ss = stringToValue<uint8_t>(rx.cap(3));
+				bp.segment = stringToValue<uint8_t>(rx.cap(4));
 				bp.condition = rx.cap(6).trimmed();
 			} else {
 				bp.condition.chop(1);
@@ -243,22 +247,22 @@ bool Breakpoints::inCurrentSlot(const Breakpoint& bp)
 {
 	if (!memLayout) return true;
 
-	int page = (bp.address & 0xC000) >> 14;
-	if (bp.ps == -1 || bp.ps == memLayout->primarySlot[page]) {
-		if (memLayout->isSubslotted[bp.ps & 3]) {
-			if (bp.ss == -1 || bp.ss == memLayout->secondarySlot[page]) {
-				if (memLayout->mapperSize[bp.ps & 3][bp.ss & 3] > 0) {
-					if (bp.segment == -1 || bp.segment == memLayout->mapperSegment[page]) {
+	int page = (bp.range.start & 0xC000) >> 14;
+	if (!bp.slot.ps || *bp.slot.ps == memLayout->primarySlot[page]) {
+		if (memLayout->isSubslotted[*bp.slot.ps & 3]) {
+			if (!bp.slot.ss || *bp.slot.ss == memLayout->secondarySlot[page]) {
+				if (memLayout->mapperSize[*bp.slot.ps & 3][*bp.slot.ss & 3] > 0) {
+					if (bp.segment || *bp.segment == memLayout->mapperSegment[page]) {
 						return true;
 					}
 				} else {
 					return true;
 				}
 			}
-		} else if (bp.ss != -1) {
+		} else if (bp.slot.ss) {
 			return false;
-		} else if (memLayout->mapperSize[bp.ps & 3][0] > 0) {
-			if (bp.segment == -1 || bp.segment == memLayout->mapperSegment[page]) {
+		} else if (memLayout->mapperSize[*bp.slot.ps & 3][0] > 0) {
+			if (!bp.segment || *bp.segment == memLayout->mapperSegment[page]) {
 				return true;
 			}
 		} else {
@@ -270,7 +274,9 @@ bool Breakpoints::inCurrentSlot(const Breakpoint& bp)
 
 void Breakpoints::insertBreakpoint(Breakpoint& bp)
 {
-	auto it = ranges::upper_bound(breakpoints, bp.address, {}, &Breakpoint::address);
+	auto it = ranges::upper_bound(breakpoints, bp.range,
+	                              [](auto& bp1, auto& bp2) { return bp1.start < bp2.start; },
+	                              &Breakpoint::range);
 	breakpoints.insert(it, bp);
 }
 
@@ -281,14 +287,14 @@ int Breakpoints::breakpointCount()
 
 bool Breakpoints::isBreakpoint(quint16 addr, QString* id, bool checkSlot)
 {
-	if (int index = findBreakpoint(addr); index != -1) {
+	if (std::optional<uint16_t> index = findBreakpoint(addr)) {
 		do {
-			const auto& bp = breakpoints[index];
+			const auto& bp = breakpoints[*index];
 			if ((!checkSlot || inCurrentSlot(bp)) && bp.type == Breakpoint::BREAKPOINT) {
 				if (id) *id = bp.id;
 				return true;
 			}
-		} while (breakpoints[++index].address == addr);
+		} while (breakpoints[++(*index)].range.start == addr);
 	}
 	return false;
 }
@@ -297,8 +303,8 @@ bool Breakpoints::isWatchpoint(quint16 addr, QString* id, bool checkSlot)
 {
 	for (const auto& bp : breakpoints) {
 		if (bp.type == Breakpoint::WATCHPOINT_MEMREAD || bp.type == Breakpoint::WATCHPOINT_MEMWRITE) {
-			if ((bp.address == addr && bp.regionEnd < bp.address) ||
-			    (addr >= bp.address && addr <= bp.regionEnd)) {
+			if ((bp.range.start == addr && !bp.range.end) ||
+			    (addr >= bp.range.start && addr <= bp.range.end)) {
 				if (!checkSlot || inCurrentSlot(bp)) {
 					if (id) *id = bp.id;
 					return true;
@@ -309,13 +315,15 @@ bool Breakpoints::isWatchpoint(quint16 addr, QString* id, bool checkSlot)
 	return false;
 }
 
-int Breakpoints::findBreakpoint(quint16 addr)
+std::optional<uint16_t>
+Breakpoints::findBreakpoint(uint16_t addr)
 {
-	if (auto i = ranges::lower_bound(breakpoints, addr, {}, &Breakpoint::address);
-	    i != breakpoints.end() && i->address == addr) {
+        if (auto i = ranges::lower_bound(breakpoints, addr,
+            [](auto& bp1, auto& addr) { return bp1.start < addr; }, &Breakpoint::range);
+	    i != breakpoints.end() && i->range.start == addr) {
 		return std::distance(breakpoints.begin(), i);
 	}
-	return -1;
+	return {};
 }
 
 const Breakpoint& Breakpoints::getBreakpoint(int index)
@@ -337,16 +345,16 @@ void Breakpoints::saveBreakpoints(QXmlStreamWriter& xml)
 		xml.writeAttribute("id", bp.id);
 
 		// slot/segment
-		xml.writeAttribute("primarySlot", QString(bp.ps < 0 ? '*' : char('0' + bp.ps)));
-		xml.writeAttribute("secondarySlot", QString(bp.ss < 0 ? '*' : char('0' + bp.ss)));
-		xml.writeAttribute("segment", QString::number(bp.segment));
+		xml.writeAttribute("primarySlot", QString(bp.slot.ps ? QChar('0' + *bp.slot.ps) : '*'));
+		xml.writeAttribute("secondarySlot", QString(bp.slot.ss ? QChar('0' + *bp.slot.ss) : '*'));
+		xml.writeAttribute("segment", QString::number(*bp.segment));
 
 		// address
 		if (bp.type == Breakpoint::BREAKPOINT) {
-			xml.writeTextElement("address", QString::number(bp.address));
+			xml.writeTextElement("address", QString::number(bp.range.start));
 		} else if (bp.type != Breakpoint::CONDITION) {
-			xml.writeTextElement("regionStart", QString::number(bp.address));
-			xml.writeTextElement("regionEnd", QString::number(bp.regionEnd));
+			xml.writeTextElement("regionStart", QString::number(bp.range.start));
+			if (bp.range.end) xml.writeTextElement("regionEnd", QString::number(*bp.range.end));
 		}
 
 		// condition
@@ -387,19 +395,26 @@ void Breakpoints::loadBreakpoints(QXmlStreamReader& xml)
 
 				// slot/segment
 				char c = xml.attributes().value("primarySlot").at(0).toLatin1();
-				bp.ps = c >= '0' && c <= '3' ? c - '0' : -1;
+				bp.slot.ps = make_if(c >= '0' && c <= '3', c - '0');
 				c = xml.attributes().value("secondarySlot").at(0).toLatin1();
-				bp.ss = c >= '0' && c <= '3' ? c - '0' : -1;
-				bp.segment = xml.attributes().value("segment").toString().toInt();
+				bp.slot.ss = make_if(c >= '0' && c <= '3', c - '0');
+				bp.segment = stringToValue<uint8_t>(xml.attributes().value("segment")
+						.toString());
 
 			} else if (xml.name() == "address" || xml.name() == "regionStart") {
 				// read symbol name
-				bp.address = xml.readElementText().toInt();
-				if (bp.type == Breakpoint::BREAKPOINT) bp.regionEnd = bp.address;
+				auto s = xml.readElementText();
+				auto start = stringToValue<uint16_t>(s);
+				if (!start) {
+					qWarning() << "breakpoint starting range invalid:" << s;
+					continue;
+				}
+				bp.range.start = *start;
+				if (bp.type == Breakpoint::BREAKPOINT) bp.range.end = {};
 
 			} else if (xml.name() == "regionEnd") {
 				// read symbol name
-				bp.regionEnd = xml.readElementText().toInt();
+				bp.range.end = stringToValue<uint16_t>(xml.readElementText());
 			} else if (xml.name() == "condition") {
 				bp.condition = xml.readElementText().trimmed();
 			}

--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -1083,8 +1083,7 @@ void DebuggerForm::searchGoto()
 {
 	GotoDialog gtd(memLayout, &session, this);
 	if (gtd.exec()) {
-		auto addr = gtd.address();
-		if (addr) {
+		if (auto addr = gtd.address()) {
 			disasmView->setCursorAddress(*addr, 0, DisasmViewer::MiddleAlways);
 		}
 	}
@@ -1152,7 +1151,7 @@ void DebuggerForm::toggleBreakpointAddress(uint16_t addr)
 		// get slot
 		auto [ps, ss, seg] = addressSlot(addr);
 		// create command
-		cmd = Breakpoints::createSetCommand(Breakpoint::BREAKPOINT, AddressRange{addr, {}},
+		cmd = Breakpoints::createSetCommand(Breakpoint::BREAKPOINT, AddressRange{addr},
 		                                    Slot{ps, ss}, seg);
 	}
 	comm.sendCommand(new SimpleCommand(cmd));
@@ -1166,7 +1165,7 @@ void DebuggerForm::addBreakpoint()
 	uint16_t addr = disasmView->cursorAddress();
 	auto [ps, ss, seg] = addressSlot(addr);
 
-	bpd.setData(Breakpoint::BREAKPOINT, AddressRange{addr, {}}, Slot{ps, ss}, seg);
+	bpd.setData(Breakpoint::BREAKPOINT, AddressRange{addr}, Slot{ps, ss}, seg);
 
 	if (bpd.exec()) {
 		if (bpd.addressRange()) {
@@ -1487,11 +1486,11 @@ DebuggerForm::AddressSlotResult DebuggerForm::addressSlot(int addr) const
 
 	std::optional<uint8_t> segment = [&] { // figure out (rom) mapper segment
 		if (ss && memLayout.mapperSize[ps][*ss] > 0) {
-			return std::optional((uint8_t) memLayout.mapperSegment[p]);
+			return std::optional(uint8_t(memLayout.mapperSegment[p]));
 		} else {
 			int q = 2 * p + ((addr & 0x2000) >> 13);
 			int b = memLayout.romBlock[q];
-			return make_if(b >= 0, (uint8_t) b);
+			return make_if(b >= 0, uint8_t(b));
 		}
 	}();
 	return {ps, ss, segment};

--- a/src/DebuggerForm.h
+++ b/src/DebuggerForm.h
@@ -57,9 +57,9 @@ private:
 	void refreshBreakpoints();
 
 	struct AddressSlotResult {
-		qint8 ps;
-		qint8 ss;
-		int segment;
+		uint8_t ps;
+		std::optional<uint8_t> ss;
+		std::optional<uint8_t> segment;
 	};
 	AddressSlotResult addressSlot(int addr) const;
 
@@ -182,7 +182,9 @@ private:
 	void executeRunTo();
 	void executeStepOut();
 	void executeStepBack();
-	void toggleBreakpoint(int addr = -1);
+
+	void toggleBreakpoint();
+	void toggleBreakpointAddress(uint16_t addr);
 	void addBreakpoint();
 
 	void toggleView(DockableWidget* widget);

--- a/src/GotoDialog.cpp
+++ b/src/GotoDialog.cpp
@@ -21,16 +21,17 @@ GotoDialog::GotoDialog(const MemoryLayout& ml, DebugSession *session, QWidget* p
 	connect(edtAddress,  SIGNAL(textEdited(const QString&)), this, SLOT(addressChanged(const QString&)));
 }
 
-int GotoDialog::address()
+std::optional<uint16_t> GotoDialog::address()
 {
 	return currentSymbol ? currentSymbol->value()
-	                     : stringToValue(edtAddress->text());
+	                     : stringToValue<int>(edtAddress->text());
 }
 
 void GotoDialog::addressChanged(const QString& text)
 {
-	int addr = stringToValue(text);
-	if (addr == -1 && debugSession) {
+	auto addr = stringToValue<uint16_t>(text);
+
+	if (addr && debugSession) {
 		// try finding a label
 		currentSymbol = debugSession->symbolTable().getAddressSymbol(text);
 		if (!currentSymbol) currentSymbol = debugSession->symbolTable().getAddressSymbol(text, Qt::CaseInsensitive);
@@ -38,6 +39,6 @@ void GotoDialog::addressChanged(const QString& text)
 	}
 
 	QPalette pal;
-	pal.setColor(QPalette::Text, addr==-1 ? Qt::red : Qt::black);
+	pal.setColor(QPalette::Text, addr ? Qt::black : Qt::red);
 	edtAddress->setPalette(pal);
 }

--- a/src/GotoDialog.h
+++ b/src/GotoDialog.h
@@ -3,6 +3,7 @@
 
 #include "ui_GotoDialog.h"
 #include <QDialog>
+#include <optional>
 
 struct MemoryLayout;
 
@@ -15,7 +16,7 @@ class GotoDialog : public QDialog, private Ui::GotoDialog
 public:
 	GotoDialog(const MemoryLayout& ml, DebugSession* session = nullptr, QWidget* parent = nullptr);
 
-	int address();
+	std::optional<uint16_t> address();
 
 private:
 	const MemoryLayout& memLayout;

--- a/src/MainMemoryViewer.cpp
+++ b/src/MainMemoryViewer.cpp
@@ -101,17 +101,15 @@ void MainMemoryViewer::hexViewChanged(int addr)
 
 void MainMemoryViewer::addressValueChanged()
 {
-	int addr = stringToValue(addressValue->text());
-	if (addr == -1 && symTable) {
+	auto addr = stringToValue<uint16_t>(addressValue->text());
+	if (!addr && symTable) {
 		// try finding a label
 		Symbol *s = symTable->getAddressSymbol(addressValue->text());
 		if (!s) s = symTable->getAddressSymbol(addressValue->text(), Qt::CaseInsensitive);
 		if (s) addr = s->value();
 	}
 
-	if (addr >= 0) {
-		hexView->setLocation(addr);
-	}
+	if (addr) hexView->setLocation(*addr);
 }
 
 void MainMemoryViewer::registerChanged(int id, int value)

--- a/src/SpriteViewer.cpp
+++ b/src/SpriteViewer.cpp
@@ -262,12 +262,12 @@ void SpriteViewer::decodeVDPregs()
 
 void SpriteViewer::on_le_patterntable_textChanged(const QString& arg1)
 {
-    if (int i = stringToValue(arg1); i != -1) {
-        spAtAddr = i;
-        imageWidget->setPatternTableAddress(i);
-        imageWidgetSingle->setPatternTableAddress(i);
-        imageWidgetSpat->setPatternTableAddress(i);
-        imageWidgetColor->setPatternTableAddress(i);
+    if (auto i = stringToValue<int>(arg1)) {
+        spAtAddr = *i;
+        imageWidget->setPatternTableAddress(*i);
+        imageWidgetSingle->setPatternTableAddress(*i);
+        imageWidgetSpat->setPatternTableAddress(*i);
+        imageWidgetColor->setPatternTableAddress(*i);
         auto font = ui->le_patterntable->font();
         font.setItalic(false);
         ui->le_patterntable->setFont(font);
@@ -280,11 +280,11 @@ void SpriteViewer::on_le_patterntable_textChanged(const QString& arg1)
 
 void SpriteViewer::on_le_attributentable_textChanged(const QString& arg1)
 {
-    if (int i = stringToValue(arg1); i != -1) {
-        imageWidget->setAttributeTableAddress(i);
-        imageWidgetSingle->setAttributeTableAddress(i);
-        imageWidgetSpat->setAttributeTableAddress(i);
-        imageWidgetColor->setAttributeTableAddress(i);
+    if (auto i = stringToValue<int>(arg1)) {
+        imageWidget->setAttributeTableAddress(*i);
+        imageWidgetSingle->setAttributeTableAddress(*i);
+        imageWidgetSpat->setAttributeTableAddress(*i);
+        imageWidgetColor->setAttributeTableAddress(*i);
         auto font = ui->le_attributentable->font();
         font.setItalic(false);
         ui->le_attributentable->setFont(font);
@@ -369,12 +369,12 @@ void SpriteViewer::on_cb_spritemode_currentIndexChanged(int index)
 
 void SpriteViewer::on_le_colortable_textChanged(const QString& arg1)
 {
-    if (int i = stringToValue(arg1); i != -1) {
-        spColAddr = i;
-        imageWidget->setColorTableAddress(i);
-        imageWidgetSingle->setColorTableAddress(i);
-        imageWidgetSpat->setColorTableAddress(i);
-        imageWidgetColor->setColorTableAddress(i);
+    if (auto i = stringToValue<int>(arg1)) {
+        spColAddr = *i;
+        imageWidget->setColorTableAddress(*i);
+        imageWidgetSingle->setColorTableAddress(*i);
+        imageWidgetSpat->setColorTableAddress(*i);
+        imageWidgetColor->setColorTableAddress(*i);
         auto font = ui->le_patterntable->font();
         font.setItalic(false);
         ui->le_patterntable->setFont(font);

--- a/src/SymbolManager.cpp
+++ b/src/SymbolManager.cpp
@@ -324,8 +324,8 @@ void SymbolManager::labelChanged(QTreeWidgetItem* item, int column)
 		if (symText.isEmpty()) symText = "[unnamed]";
 		sym->setText(symText);
 		// set value TODO: proper decoding of value
-		int value = stringToValue(item->text(2));
-		if (value >= 0 && value < 65536) sym->setValue(value);
+		auto value = stringToValue<uint16_t>(item->text(2));
+		if (value) sym->setValue(*value);
 		treeLabels->closePersistentEditor(item, column);
 		editColumn = -1;
 		// update item name and value

--- a/src/TileViewer.cpp
+++ b/src/TileViewer.cpp
@@ -259,8 +259,8 @@ void TileViewer::on_cb_screen_currentIndexChanged(int index)
 void TileViewer::on_le_nametable_textChanged(const QString& text)
 {
     auto font = le_nametable->font();
-    if (int i = stringToValue(text); i != -1) {
-        imageWidget->setNameTableAddress(i);
+    if (auto i = stringToValue<int>(text)) {
+        imageWidget->setNameTableAddress(*i);
         font.setItalic(false);
     } else {
         font.setItalic(true);
@@ -271,8 +271,8 @@ void TileViewer::on_le_nametable_textChanged(const QString& text)
 void TileViewer::on_le_colortable_textChanged(const QString& text)
 {
     auto font = le_colortable->font();
-    if (int i = stringToValue(text); i != -1) {
-        imageWidget->setColorTableAddress(i);
+    if (auto i = stringToValue<int>(text)) {
+        imageWidget->setColorTableAddress(*i);
         font.setItalic(false);
     } else {
         font.setItalic(true);
@@ -283,8 +283,8 @@ void TileViewer::on_le_colortable_textChanged(const QString& text)
 void TileViewer::on_le_patterntable_textChanged(const QString& text)
 {
     auto font = le_patterntable->font();
-    if (int i = stringToValue(text); i != -1) {
-        imageWidget->setPatternTableAddress(i);
+    if (auto i = stringToValue<int>(text)) {
+        imageWidget->setPatternTableAddress(*i);
         font.setItalic(false);
     } else {
         font.setItalic(true);

--- a/src/VDPCommandRegViewer.cpp
+++ b/src/VDPCommandRegViewer.cpp
@@ -76,11 +76,11 @@ VDPCommandRegViewer::~VDPCommandRegViewer()
 void VDPCommandRegViewer::on_lineEdit_r45_editingFinished()
 {
 	//for now simply recheck all the checkBoxes and recreate R45
-	int val = stringToValue(lineEdit_r45->text());
+	auto val = stringToValue<int>(lineEdit_r45->text());
 	int r45 = 0;
 	for (auto* item : findChildren<QCheckBox*>()) {
 	        int order = QString(item->objectName().right(1)).toInt();
-		if (val & (1 << order)) {
+		if (val && *val & (1 << order)) {
 			r45 = r45 | (1 << order);
 			item->setChecked(true);
 		} else {
@@ -193,23 +193,22 @@ void VDPCommandRegViewer::on_syncPushButton_clicked()
 
 void VDPCommandRegViewer::on_launchPushButton_clicked()
 {
-	unsigned char newregs[64];
-	memset(newregs, 0, 64);
-	newregs[32] = stringToValue(lineEdit_r32->text());
-	newregs[33] = stringToValue(lineEdit_r33->text());
-	newregs[34] = stringToValue(lineEdit_r34->text());
-	newregs[35] = stringToValue(lineEdit_r35->text());
-	newregs[36] = stringToValue(lineEdit_r36->text());
-	newregs[37] = stringToValue(lineEdit_r37->text());
-	newregs[38] = stringToValue(lineEdit_r38->text());
-	newregs[39] = stringToValue(lineEdit_r39->text());
-	newregs[40] = stringToValue(lineEdit_r40->text());
-	newregs[41] = stringToValue(lineEdit_r41->text());
-	newregs[42] = stringToValue(lineEdit_r42->text());
-	newregs[43] = stringToValue(lineEdit_r43->text());
-	newregs[44] = stringToValue(lineEdit_r44->text());
-	newregs[45] = stringToValue(lineEdit_r45->text());
-	newregs[46] = stringToValue(lineEdit_r46->text());
+	uint8_t newregs[64] = {};
+	newregs[32] = stringToValue<uint8_t>(lineEdit_r32->text()).value_or(255);
+	newregs[33] = stringToValue<uint8_t>(lineEdit_r33->text()).value_or(255);
+	newregs[34] = stringToValue<uint8_t>(lineEdit_r34->text()).value_or(255);
+	newregs[35] = stringToValue<uint8_t>(lineEdit_r35->text()).value_or(255);
+	newregs[36] = stringToValue<uint8_t>(lineEdit_r36->text()).value_or(255);
+	newregs[37] = stringToValue<uint8_t>(lineEdit_r37->text()).value_or(255);
+	newregs[38] = stringToValue<uint8_t>(lineEdit_r38->text()).value_or(255);
+	newregs[39] = stringToValue<uint8_t>(lineEdit_r39->text()).value_or(255);
+	newregs[40] = stringToValue<uint8_t>(lineEdit_r40->text()).value_or(255);
+	newregs[41] = stringToValue<uint8_t>(lineEdit_r41->text()).value_or(255);
+	newregs[42] = stringToValue<uint8_t>(lineEdit_r42->text()).value_or(255);
+	newregs[43] = stringToValue<uint8_t>(lineEdit_r43->text()).value_or(255);
+	newregs[44] = stringToValue<uint8_t>(lineEdit_r44->text()).value_or(255);
+	newregs[45] = stringToValue<uint8_t>(lineEdit_r45->text()).value_or(255);
+	newregs[46] = stringToValue<uint8_t>(lineEdit_r46->text()).value_or(255);
 
 	auto* req = new WriteDebugBlockCommand("{VDP regs}", 32, 15, newregs);
 	CommClient::instance().sendCommand(req);
@@ -217,10 +216,10 @@ void VDPCommandRegViewer::on_launchPushButton_clicked()
 
 void VDPCommandRegViewer::on_lineEdit_r44_editingFinished()
 {
-	int val = stringToValue(lineEdit_r44->text());
+	auto val = stringToValue<int>(lineEdit_r44->text());
 	label_color->setText(QString("%1 %2").
-			arg((val >> 4) & 15, 4, 2, QChar('0')).
-			arg((val >> 0) & 15, 4, 2, QChar('0')));
+			arg((val.value_or(-1) >> 4) & 15, 4, 2, QChar('0')).
+			arg((val.value_or(-1) >> 0) & 15, 4, 2, QChar('0')));
 }
 
 void VDPCommandRegViewer::R45BitChanged(int /*state*/)
@@ -239,12 +238,13 @@ void VDPCommandRegViewer::R45BitChanged(int /*state*/)
 
 void VDPCommandRegViewer::on_lineEdit_r46_editingFinished()
 {
-	int val = stringToValue(lineEdit_r46->text()) & 0xFF;
-	lineEdit_r46->setText(hexValue(val, 2));
-	R46 = val;
-	decodeR46(R46);
-	comboBox_operator->setCurrentIndex(R46 & 15);
-	comboBox_cmd->setCurrentIndex((R46 >> 4) & 15); // this might hide the operator again :-)
+	if (auto val = stringToValue<uint8_t>(lineEdit_r46->text())) {
+		lineEdit_r46->setText(hexValue(*val, 2));
+		R46 = *val;
+		decodeR46(R46);
+		comboBox_operator->setCurrentIndex(R46 & 15);
+		comboBox_cmd->setCurrentIndex((R46 >> 4) & 15); // this might hide the operator again :-)
+	}
 }
 
 void VDPCommandRegViewer::refresh()

--- a/src/VDPCommandRegViewer.h
+++ b/src/VDPCommandRegViewer.h
@@ -40,29 +40,29 @@ public slots:
 
 	void setRH(const QString& newval)
 	{
-		int val = stringToValue(newval) & 0xFF;
-		if ((val == -1) || (val == rh)) return;
+		auto val = stringToValue<uint8_t>(newval);
+        if (!val || (*val == rh)) return;
 
-		rh = val;
+		rh = *val;
 		updaterw();
 		updaterh();
 	}
 	void setRL(const QString& newval)
 	{
-		int val = stringToValue(newval) & 0xFF;
-		if ((val == -1) || (val == rl)) return;
+		auto val = stringToValue<uint8_t>(newval);
+        if (!val || (*val == rl)) return;
 
-		rl = val;
+		rl = *val;
 		updaterw();
 		updaterl();
 	}
 	void setRW(const QString& newval)
 	{
 		//TODO: build a split-in-two method
-		int val = stringToValue(newval) & 0xFFFF;
-		if ((val == -1) || (val == rw)) return;
+		auto val = stringToValue<uint16_t>(newval);
+        if (!val || (*val == rw)) return;
 
-		rw = val;
+		rw = *val;
 		updaterl();
 		updaterh();
 		updaterw();


### PR DESCRIPTION
* `make_positive_optional` (tentative name) function converts negative (interpreted in many places as invalid or generic value) into optional null.
* `createSetCommand` now uses `AddressRange` and `Slot` structs;
* `stringToValue` returns `optional<int>` because string may not be convertible;
* `BreakpointDialog` now returns `Slot` and `AddressRange` structs;
* `segment` should now fit in a `uint8_t`, since `-1` is not used anymore to mean any or no segment;
* `stringToValue` now has a parametric type (defaults to `int`) to avoid the 0xFFFF or 0xFF masks;
  * rejects value when overflow is detected;
* `make_if` functions used to create optionals more easily;
* `Breakpoint::range` is optional because conditions don't use them.