### PR TITLE
deprecated warnings

### DIFF
--- a/src/BitMapViewer.cpp
+++ b/src/BitMapViewer.cpp
@@ -30,7 +30,7 @@ BitMapViewer::BitMapViewer(QWidget* parent)
 {
 	setupUi(this);
     //no connect slot byname anymore
-    connect(screenMode, qOverload<const QString&>(&QComboBox:: currentIndexChanged), this, &BitMapViewer::on_screenMode_currentIndexChanged);
+    connect(screenMode, qOverload<int>(&QComboBox::currentIndexChanged), this, &BitMapViewer::on_screenMode_currentIndexChanged);
     connect(showPage, qOverload<int>(&QComboBox:: currentIndexChanged), this, &BitMapViewer::on_showPage_currentIndexChanged);
     connect(linesVisible, qOverload<int>(&QComboBox:: currentIndexChanged), this, &BitMapViewer::on_linesVisible_currentIndexChanged);
     connect(bgColor,  qOverload<int>(&QSpinBox::valueChanged), this, &BitMapViewer::on_bgColor_valueChanged);
@@ -171,9 +171,9 @@ void BitMapViewer::refresh()
 	VDPDataStore::instance().refresh();
 }
 
-void BitMapViewer::on_screenMode_currentIndexChanged(const QString& text)
+void BitMapViewer::on_screenMode_currentIndexChanged(int index)
 {
-	screenMod = text.toInt();
+	screenMod = screenMode->itemText(index).toInt();
 	printf("\nnew screenMod: %i\n", screenMod);
 	//change then number of visibe pages when this changes
 	imageWidget->setVramAddress(0);

--- a/src/BitMapViewer.h
+++ b/src/BitMapViewer.h
@@ -17,7 +17,7 @@ private:
 	void decodeVDPregs();
 	void setPages();
 
-	void on_screenMode_currentIndexChanged(const QString& text);
+	void on_screenMode_currentIndexChanged(int index);
 	void on_showPage_currentIndexChanged(int index);
 	void on_linesVisible_currentIndexChanged(int index);
 	void on_bgColor_valueChanged(int value);


### PR DESCRIPTION
Removing this warning:
```
Compiling BitMapViewer.cpp...
src/BitMapViewer.cpp: In constructor ‘BitMapViewer::BitMapViewer(QWidget*)’:
src/BitMapViewer.cpp:33:50: warning: ‘void QComboBox::currentIndexChanged(const QString&)’ is deprecated: Use currentIndexChanged(int) instead, and get the text using itemText(index) [-Wdeprecated-declarations]
   33 |     connect(screenMode, qOverload<const QString&>(&QComboBox:: currentIndexChanged), this, &BitMapViewer::on_screenMode_currentIndexChanged);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```