### PR TITLE
Stop "CPU registers changes" modal window from showing up twice, thri…

### DIFF
--- a/src/CPURegsViewer.cpp
+++ b/src/CPURegsViewer.cpp
@@ -359,22 +359,29 @@ void CPURegsViewer::applyModifications()
 
 void CPURegsViewer::cancelModifications()
 {
+	static bool isVisible = false;
 	bool mod = false;
+
 	for (int i = 0; i < 14; ++i) mod |= regsModified[i];
 	if (!mod) return;
 
-	int ret = QMessageBox::warning(
-		this,
-		tr("CPU registers changes"),
-		tr("You made changes to the CPU registers.\n"
-		   "Do you want to apply your changes or ignore them?"),
-		QMessageBox::Apply | QMessageBox::Ignore,
-		QMessageBox::Ignore);
-	if (ret == QMessageBox::Ignore) {
-		memcpy(&regs, &regsCopy, sizeof(regs));
-		memset(&regsModified, 0, sizeof(regsModified));
-	} else {
-		applyModifications();
+	if (!isVisible) {
+		isVisible = true;
+		// this modal window blocks execution of next instruction
+		int ret = QMessageBox::warning(
+			this,
+			tr("CPU registers changes"),
+			tr("You made changes to the CPU registers.\n"
+			   "Do you want to apply your changes or ignore them?"),
+			QMessageBox::Apply | QMessageBox::Ignore,
+			QMessageBox::Ignore);
+		isVisible = false;
+		if (ret == QMessageBox::Ignore) {
+			memcpy(&regs, &regsCopy, sizeof(regs));
+			memset(&regsModified, 0, sizeof(regsModified));
+		} else {
+			applyModifications();
+		}
 	}
 }
 


### PR DESCRIPTION
…ce and more

How to replicate this error:
* change a CPU register in CPURegsView;
* Press ESCAPE or change focus to display modal "CPU registers changes" window;
* Change focus to and from app again;
* lostFocus event will be triggered showing up the modal window again;
* Keep changing focus in and out of the debugger to display a new modal window;

![image](https://user-images.githubusercontent.com/7815819/170802705-addadf6a-9700-4048-8adf-058cfb4b97ac.png)
