### PR TITLE
optionally preserve lost symbol

### DIFF
--- a/src/DebuggerForm.h
+++ b/src/DebuggerForm.h
@@ -4,8 +4,10 @@
 #include "DockableWidgetArea.h"
 #include "DockManager.h"
 #include "DebugSession.h"
+#include "SymbolManager.h"
 #include <QMainWindow>
 #include <QMap>
+#include <QPointer>
 #include <cstdint>
 #include <memory>
 
@@ -138,6 +140,7 @@ private:
 	VDPRegViewer* VDPRegView;
 	VDPCommandRegViewer* VDPCommandRegView;
 	BreakpointViewer* bpView;
+	QPointer<SymbolManager> symManager;
 
 	CommClient& comm;
 	DebugSession session;
@@ -216,6 +219,7 @@ signals:
 	void connected();
 	void settingsChanged();
 	void symbolsChanged();
+	void symbolFilesChanged();
 	void runStateEntered();
 	void breakStateEntered();
 	void breakpointsUpdated();

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -22,10 +22,23 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	connect(btnFontColor,  &QPushButton::clicked,
 	        this, &PreferencesDialog::fontSelectColor);
 
+	connect(cbPreserveLostSymbols, &QCheckBox::stateChanged,
+			this, &PreferencesDialog::preserveLostSymbols);
+
+	initConfig();
 	initFontList();
 	listFonts->setCurrentRow(0);
 }
 
+/*
+ * Config settings
+ */
+void PreferencesDialog::initConfig()
+{
+	Settings& s = Settings::get();
+	int status = s.preserveLostSymbols() ? Qt::Checked : Qt::Unchecked;
+	cbPreserveLostSymbols->setChecked(status);
+}
 /*
  * Font settings
  */
@@ -107,6 +120,11 @@ void PreferencesDialog::fontSelectColor()
 		Settings::get().setFontColor(f, newColor);
 		setFontPreviewColor(newColor);
 	}
+}
+
+void PreferencesDialog::preserveLostSymbols(int state)
+{
+	Settings::get().setPreserveLostSymbols(state == Qt::Checked);
 }
 
 void PreferencesDialog::setFontPreviewColor(const QColor& c)

--- a/src/PreferencesDialog.h
+++ b/src/PreferencesDialog.h
@@ -11,6 +11,7 @@ public:
 	PreferencesDialog(QWidget* parent = nullptr);
 
 private:
+	void initConfig();
 	void initFontList();
 	void setFontPreviewColor(const QColor& c);
 
@@ -18,6 +19,8 @@ private:
 	void fontTypeChanged(bool state);
 	void fontSelectCustom();
 	void fontSelectColor();
+
+	void preserveLostSymbols(int state);
 
 private:
 	bool updating;

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -24,6 +24,27 @@
    </property>
    <item>
     <widget class="QTabWidget" name="tabWidget" >
+     <widget class="QWidget" name="tabSym" >
+      <attribute name="title" >
+       <string>Symbol Table</string>
+      </attribute>
+      <widget class="QCheckBox" name="cbPreserveLostSymbols" >
+       <property name="geometry">
+        <rect>
+         <x>6</x>
+         <y>6</y>
+         <width>242</width>
+         <height>25</height>
+        </rect>
+       </property>
+       <property name="text" >
+        <string>Preserve lost symbols on reload</string>
+       </property>
+       <property name="checked" >
+        <bool>true</bool>
+       </property>
+      </widget>
+     </widget>
      <widget class="QWidget" name="tabFonts" >
       <attribute name="title" >
        <string>Fonts</string>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,10 +1,19 @@
 #include "Settings.h"
 #include <QApplication>
 
+static const char* DebuggerConfigNames[Settings::CONFIG_END] = {
+	"Preserve Lost Symbols"
+};
+
 static const char* DebuggerFontNames[Settings::FONT_END] = {
 	"Application Font", "Default Fixed Font", "Code Font",
 	"Label Font", "Hex viewer font"
 };
+
+static QString configLocation(Settings::DebuggerConfig c)
+{
+	return QString("Config/").append(DebuggerConfigNames[c]);
+}
 
 static QString fontLocation(Settings::DebuggerFont f)
 {
@@ -19,6 +28,7 @@ static QString fontColorLocation(Settings::DebuggerFont f)
 Settings::Settings()
 	: QSettings("openMSX", "debugger")
 {
+	getConfigFromSettings();
 	getFontsFromSettings();
 }
 
@@ -26,6 +36,23 @@ Settings& Settings::get()
 {
 	static Settings instance;
 	return instance;
+}
+
+void Settings::getConfigFromSettings()
+{
+	QVariant b = value(configLocation(PRESERVE_LOST_SYMBOLS));
+	if (b.type() == QVariant::Invalid) {
+		// default value
+		config[PRESERVE_LOST_SYMBOLS] = true;
+	} else if (b.type() == QVariant::Bool) {
+		config[PRESERVE_LOST_SYMBOLS] = b.value<bool>();
+	}
+}
+
+void Settings::setConfig(DebuggerConfig c, const QVariant& v)
+{
+	config[c] = v;
+	setValue(configLocation(c), config[c]);
 }
 
 void Settings::getFontsFromSettings()
@@ -134,6 +161,17 @@ void Settings::setFontColor(DebuggerFont f, const QColor& c)
 		fontColors[f] = c;
 		setValue(fontColorLocation(f), c);
 	}
+}
+
+bool Settings::preserveLostSymbols() const
+{
+	return config[PRESERVE_LOST_SYMBOLS].value<bool>();
+}
+
+void Settings::setPreserveLostSymbols(bool b)
+{
+	config[PRESERVE_LOST_SYMBOLS] = b;
+	setValue(configLocation(PRESERVE_LOST_SYMBOLS), config[PRESERVE_LOST_SYMBOLS]);
 }
 
 void Settings::updateFonts()

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -9,6 +9,9 @@ class Settings : public QSettings
 {
 	Q_OBJECT
 public:
+	enum DebuggerConfig {
+		PRESERVE_LOST_SYMBOLS, CONFIG_END
+	};
 	enum DebuggerFont {
 		APP_FONT, FIXED_FONT, CODE_FONT, LABEL_FONT, HEX_FONT, FONT_END
 	};
@@ -26,6 +29,10 @@ public:
 	const QColor& fontColor(DebuggerFont f) const;
 	void setFontColor(DebuggerFont f, const QColor& c);
 
+	bool preserveLostSymbols() const;
+	void setPreserveLostSymbols(bool b);
+	void setConfig(DebuggerConfig c, const QVariant& v);
+
 private:
 	Settings();
 	~Settings() override = default;
@@ -34,6 +41,10 @@ private:
 	DebuggerFontType fontTypes[FONT_END];
 	QColor fontColors[FONT_END];
 
+	// bool preserveLostSymbols_;
+	QVariant config[CONFIG_END];
+
+	void getConfigFromSettings();
 	void getFontsFromSettings();
 	void updateFonts();
 };

--- a/src/SymbolManager.cpp
+++ b/src/SymbolManager.cpp
@@ -99,6 +99,11 @@ void SymbolManager::closeEvent(QCloseEvent* e)
 	QDialog::closeEvent(e);
 }
 
+void SymbolManager::refresh()
+{
+	initSymbolList();
+}
+
 /*
  * File list support functions
  */

--- a/src/SymbolManager.h
+++ b/src/SymbolManager.h
@@ -12,6 +12,8 @@ class SymbolManager : public QDialog, private Ui::SymbolManager
 public:
 	SymbolManager(SymbolTable& symtable, QWidget* parent = nullptr);
 
+	void refresh();
+
 signals:
 	void symbolTableChanged();
 

--- a/src/SymbolTable.cpp
+++ b/src/SymbolTable.cpp
@@ -1,4 +1,5 @@
 #include "SymbolTable.h"
+#include "Settings.h"
 #include "DebuggerData.h"
 #include <QFile>
 #include <QTextStream>
@@ -531,11 +532,13 @@ void SymbolTable::reloadFiles()
 			s->setStatus((sit->status() == Symbol::LOST) ? Symbol::ACTIVE : sit->status());
 			symCopy.erase(sit);
 		}
-		// all symbols left in map are lost
-		for (auto sit = symCopy.begin(); sit != symCopy.end(); ++sit) {
-			auto* sym = add(std::make_unique<Symbol>(sit.value()));
-			sym->setStatus(Symbol::LOST);
-			sym->setSource(newFile);
+		if (Settings::get().preserveLostSymbols()) {
+			// all symbols left in map are lost
+			for (auto sit = symCopy.begin(); sit != symCopy.end(); ++sit) {
+				auto* sym = add(std::make_unique<Symbol>(sit.value()));
+				sym->setStatus(Symbol::LOST);
+				sym->setSource(newFile);
+			}
 		}
 	}
 }

--- a/tmp.ui
+++ b/tmp.ui
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>350</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QCheckBox" name="checkBox">
+   <property name="geometry">
+    <rect>
+     <x>7</x>
+     <y>38</y>
+     <width>244</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Ignore changes to symbol files</string>
+   </property>
+  </widget>
+  <widget class="QCheckBox" name="checkBox_2">
+   <property name="geometry">
+    <rect>
+     <x>7</x>
+     <y>7</y>
+     <width>242</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Preserve lost symbols on reload</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Allow the debugger to forget old symbols, because it tends to get saturated with old and invalid labels in the symbol table. This patch also creates an entry on the preferences dialog.
![image](https://user-images.githubusercontent.com/7815819/213897687-7a8848fd-752a-4f8a-9fcd-0b280afc5efc.png)
