### PR TITLE
Allow user to redirect symbol file to slot/subslot

### DIFF
--- a/src/SymbolManager.h
+++ b/src/SymbolManager.h
@@ -21,6 +21,7 @@ private:
 	void closeEvent(QCloseEvent* e) override;
 
 	void initFileList();
+	void createComboBox(int row);
 	void initSymbolList();
 
 	void closeEditor();
@@ -40,6 +41,7 @@ private:
 	void addFile();
 	void removeFile();
 	void reloadFiles();
+	void addSymbolFileDestination(int fileIndex, int validSlot);
 	void addLabel();
 	void removeLabel();
 	void labelEdit(QTreeWidgetItem* item, int column);
@@ -82,6 +84,7 @@ private:
 	void changeRegisterIYH(int state);
 	void changeRegisterOffset(int state);
 	void changeRegisterI(int state);
+	void wipeSelectedItem();
 
 private:
 	SymbolTable& symTable;

--- a/src/SymbolManager.ui
+++ b/src/SymbolManager.ui
@@ -57,6 +57,11 @@
          </column>
          <column>
           <property name="text" >
+           <string>Destination slot</string>
+          </property>
+         </column>
+         <column>
+          <property name="text" >
            <string>Last refresh</string>
           </property>
          </column>
@@ -224,7 +229,7 @@
              </property>
              <layout class="QHBoxLayout" >
               <item>
-               <layout class="QVBoxLayout" >
+               <layout class="QVBoxLayout" name="vbox0" >
                 <item>
                  <widget class="QCheckBox" name="chk00" >
                   <property name="text" >
@@ -256,7 +261,7 @@
                </layout>
               </item>
               <item>
-               <layout class="QVBoxLayout" >
+               <layout class="QVBoxLayout" name="vbox1" >
                 <item>
                  <widget class="QCheckBox" name="chk10" >
                   <property name="text" >
@@ -288,7 +293,7 @@
                </layout>
               </item>
               <item>
-               <layout class="QVBoxLayout" >
+               <layout class="QVBoxLayout" name="vbox2" >
                 <item>
                  <widget class="QCheckBox" name="chk20" >
                   <property name="text" >
@@ -320,7 +325,7 @@
                </layout>
               </item>
               <item>
-               <layout class="QVBoxLayout" >
+               <layout class="QVBoxLayout" name="vbox3" >
                 <item>
                  <widget class="QCheckBox" name="chk30" >
                   <property name="text" >
@@ -391,7 +396,7 @@
              <property name="title" >
               <string>Symbol type</string>
              </property>
-             <layout class="QVBoxLayout" >
+             <layout class="QVBoxLayout" name="vboxSymbolType" >
               <item>
                <widget class="QRadioButton" name="radJump" >
                 <property name="text" >
@@ -423,7 +428,7 @@
              </property>
              <layout class="QHBoxLayout" >
               <item>
-               <layout class="QGridLayout" >
+               <layout class="QGridLayout" name="gridRegs8" >
                 <property name="horizontalSpacing" >
                  <number>16</number>
                 </property>
@@ -530,7 +535,7 @@
              </property>
              <layout class="QHBoxLayout" >
               <item>
-               <layout class="QGridLayout" >
+               <layout class="QGridLayout" name="gridRegs16" >
                 <item row="0" column="0" >
                  <widget class="QCheckBox" name="chkRegBC" >
                   <property name="text" >


### PR DESCRIPTION
The contents of a symbol file can now be redirected to specific slot/subslot arrangement for better debugging experience. The `Destination segments` column doesn't work yet because the `Active segments` in the `Locations` group box doesn't do anything to begin with.
![image](https://user-images.githubusercontent.com/7815819/214222585-266a7c2b-905a-4848-8ce9-ffb83f19a9a2.png)
