### PR TITLE
Make "Symbol file changed" dialog optional

### DIFF
--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -1462,16 +1462,17 @@ void DebuggerForm::symbolFileChanged()
 {
 	static bool shown(false);
 	if (shown) return;
-	shown = true;
-	int choice = QMessageBox::question(this, tr("Symbol file changed"),
-	                tr("One or more symbol file have changed.\n"
-	                   "Reload now?"),
-	                QMessageBox::Yes | QMessageBox::No);
-	shown = false;
-	if (choice == QMessageBox::Yes) {
-		session.symbolTable().reloadFiles();
-		emit symbolFilesChanged();
+	if (!Settings::get().autoReloadSymbols()) {
+		shown = true;
+		int choice = QMessageBox::question(this, tr("Symbol file changed"),
+						tr("One or more symbol file have changed.\n"
+						"Reload now?"),
+						QMessageBox::Yes | QMessageBox::No);
+		shown = false;
+		if (choice == QMessageBox::No) return;
 	}
+	session.symbolTable().reloadFiles();
+	emit symbolFilesChanged();
 }
 
 DebuggerForm::AddressSlotResult DebuggerForm::addressSlot(int addr) const

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -22,9 +22,6 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	connect(btnFontColor,  &QPushButton::clicked,
 	        this, &PreferencesDialog::fontSelectColor);
 
-	connect(cbPreserveLostSymbols, &QCheckBox::stateChanged,
-			this, &PreferencesDialog::preserveLostSymbols);
-
 	initConfig();
 	initFontList();
 	listFonts->setCurrentRow(0);
@@ -36,8 +33,15 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 void PreferencesDialog::initConfig()
 {
 	Settings& s = Settings::get();
-	int status = s.preserveLostSymbols() ? Qt::Checked : Qt::Unchecked;
-	cbPreserveLostSymbols->setChecked(status);
+	int status1 = s.autoReloadSymbols() ? Qt::Checked : Qt::Unchecked;
+	cbAutoReloadSymbols->setChecked(status1);
+	connect(cbAutoReloadSymbols, &QCheckBox::stateChanged,
+			this, &PreferencesDialog::autoReloadSymbols);
+
+	int status2 = s.preserveLostSymbols() ? Qt::Checked : Qt::Unchecked;
+	cbPreserveLostSymbols->setChecked(status2);
+	connect(cbPreserveLostSymbols, &QCheckBox::stateChanged,
+			this, &PreferencesDialog::preserveLostSymbols);
 }
 /*
  * Font settings
@@ -120,6 +124,11 @@ void PreferencesDialog::fontSelectColor()
 		Settings::get().setFontColor(f, newColor);
 		setFontPreviewColor(newColor);
 	}
+}
+
+void PreferencesDialog::autoReloadSymbols(int state)
+{
+	Settings::get().setAutoReloadSymbols(state == Qt::Checked);
 }
 
 void PreferencesDialog::preserveLostSymbols(int state)

--- a/src/PreferencesDialog.h
+++ b/src/PreferencesDialog.h
@@ -20,6 +20,7 @@ private:
 	void fontSelectCustom();
 	void fontSelectColor();
 
+	void autoReloadSymbols(int state);
 	void preserveLostSymbols(int state);
 
 private:

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -28,11 +28,27 @@
       <attribute name="title" >
        <string>Symbol Table</string>
       </attribute>
-      <widget class="QCheckBox" name="cbPreserveLostSymbols" >
+      <widget class="QCheckBox" name="cbAutoReloadSymbols" >
        <property name="geometry">
         <rect>
          <x>6</x>
          <y>6</y>
+         <width>342</width>
+         <height>25</height>
+        </rect>
+       </property>
+       <property name="text" >
+        <string>Automatically reload symbol files that changed</string>
+       </property>
+       <property name="checked" >
+        <bool>false</bool>
+       </property>
+      </widget>
+      <widget class="QCheckBox" name="cbPreserveLostSymbols" >
+       <property name="geometry">
+        <rect>
+         <x>6</x>
+         <y>38</y>
          <width>242</width>
          <height>25</height>
         </rect>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,8 +1,9 @@
 #include "Settings.h"
 #include <QApplication>
+#include <QDebug>
 
 static const char* DebuggerConfigNames[Settings::CONFIG_END] = {
-	"Preserve Lost Symbols"
+	"AutoReloadSymbols", "PreserveLostSymbols"
 };
 
 static const char* DebuggerFontNames[Settings::FONT_END] = {
@@ -38,15 +39,22 @@ Settings& Settings::get()
 	return instance;
 }
 
+void Settings::getBoolFromSetting(DebuggerConfig c, bool defaultValue)
+{
+	QVariant v = value(configLocation(c));
+
+	if (v.canConvert<bool>()) {
+		config[c] = v;
+	} else {
+		// default value
+		config[c] = defaultValue;
+	}
+}
+
 void Settings::getConfigFromSettings()
 {
-	QVariant b = value(configLocation(PRESERVE_LOST_SYMBOLS));
-	if (b.type() == QVariant::Invalid) {
-		// default value
-		config[PRESERVE_LOST_SYMBOLS] = true;
-	} else if (b.type() == QVariant::Bool) {
-		config[PRESERVE_LOST_SYMBOLS] = b.value<bool>();
-	}
+	getBoolFromSetting(AUTO_RELOAD_SYMBOLS, false);
+	getBoolFromSetting(PRESERVE_LOST_SYMBOLS, true);
 }
 
 void Settings::setConfig(DebuggerConfig c, const QVariant& v)
@@ -163,6 +171,16 @@ void Settings::setFontColor(DebuggerFont f, const QColor& c)
 	}
 }
 
+bool Settings::autoReloadSymbols() const
+{
+	return config[AUTO_RELOAD_SYMBOLS].value<bool>();
+}
+
+void Settings::setAutoReloadSymbols(bool b)
+{
+	setConfig(AUTO_RELOAD_SYMBOLS, b);
+}
+
 bool Settings::preserveLostSymbols() const
 {
 	return config[PRESERVE_LOST_SYMBOLS].value<bool>();
@@ -170,8 +188,7 @@ bool Settings::preserveLostSymbols() const
 
 void Settings::setPreserveLostSymbols(bool b)
 {
-	config[PRESERVE_LOST_SYMBOLS] = b;
-	setValue(configLocation(PRESERVE_LOST_SYMBOLS), config[PRESERVE_LOST_SYMBOLS]);
+	setConfig(PRESERVE_LOST_SYMBOLS, b);
 }
 
 void Settings::updateFonts()

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -10,7 +10,7 @@ class Settings : public QSettings
 	Q_OBJECT
 public:
 	enum DebuggerConfig {
-		PRESERVE_LOST_SYMBOLS, CONFIG_END
+		AUTO_RELOAD_SYMBOLS, PRESERVE_LOST_SYMBOLS, CONFIG_END
 	};
 	enum DebuggerFont {
 		APP_FONT, FIXED_FONT, CODE_FONT, LABEL_FONT, HEX_FONT, FONT_END
@@ -29,6 +29,8 @@ public:
 	const QColor& fontColor(DebuggerFont f) const;
 	void setFontColor(DebuggerFont f, const QColor& c);
 
+	bool autoReloadSymbols() const;
+	void setAutoReloadSymbols(bool b);
 	bool preserveLostSymbols() const;
 	void setPreserveLostSymbols(bool b);
 	void setConfig(DebuggerConfig c, const QVariant& v);
@@ -41,9 +43,9 @@ private:
 	DebuggerFontType fontTypes[FONT_END];
 	QColor fontColors[FONT_END];
 
-	// bool preserveLostSymbols_;
 	QVariant config[CONFIG_END];
 
+	void getBoolFromSetting(DebuggerConfig c, bool defaultValue);
 	void getConfigFromSettings();
 	void getFontsFromSettings();
 	void updateFonts();


### PR DESCRIPTION
One less thing to interrupt the user when he is in a tight compile/debug cycle.