### PR TITLE
Symbol Manager can read OMDS files without changing the session

### DIFF
--- a/src/SymbolManager.cpp
+++ b/src/SymbolManager.cpp
@@ -156,7 +156,8 @@ void SymbolManager::addFile()
 	// create dialog
 	auto* d = new QFileDialog(this);
 	QStringList types;
-	types << "All supported files (*.sym *.map *.noi *.symbol *.publics *.sys)"
+	types << "All supported files (*.omds *.sym *.map *.noi *.symbol *.publics *.sys)"
+		  << "OpenMSX Debugger session files (*.omds)"
 	      << "tniASM 0.x symbol files (*.sym)"
 	      << "tniASM 1.x symbol files (*.sym)"
 	      << "asMSX 0.x symbol files (*.sym)"
@@ -175,7 +176,9 @@ void SymbolManager::addFile()
 		QString n = d->selectedFiles().at(0);
 		// load file from the correct type
 		bool read = false;
-		if        (f.startsWith("tniASM 0")) {
+		if        (f.startsWith("OpenMSX Debugger session")) {
+			read = symTable.readFile(n, SymbolTable::OMDS_FILE);
+		} else if (f.startsWith("tniASM 0")) {
 			read = symTable.readFile(n, SymbolTable::TNIASM0_FILE);
 		} else if (f.startsWith("tniASM 1")) {
 			read = symTable.readFile(n, SymbolTable::TNIASM1_FILE);

--- a/src/SymbolTable.cpp
+++ b/src/SymbolTable.cpp
@@ -6,6 +6,7 @@
 #include <QStringList>
 #include <QRegExp>
 #include <QFileInfo>
+#include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 #include <QMap>
 #include <algorithm>
@@ -190,7 +191,10 @@ bool SymbolTable::readFile(const QString& filename, FileType type)
 	QString fname = filename.toLower();
 
 	if (type == DETECT_FILE) {
-		if (fname.endsWith(".noi")) {
+		if (fname.endsWith(".omds")) {
+			// OpenMSX Debugger session file
+			type = OMDS_FILE;
+		} else if (fname.endsWith(".noi")) {
 			// NoICE command file
 			type = NOICE_FILE;
 		} else if (fname.endsWith(".map")) {
@@ -227,6 +231,8 @@ bool SymbolTable::readFile(const QString& filename, FileType type)
 		}
 	}
 	switch (type) {
+	case OMDS_FILE:
+		return readOMDSFile(filename);
 	case TNIASM0_FILE:
 		return readTNIASM0File(filename);
 	case TNIASM1_FILE:
@@ -301,6 +307,18 @@ bool SymbolTable::readSymbolFile(
 			add(std::make_unique<Symbol>(l.at(0), *value, source));
 		}
 	}
+	return true;
+}
+bool SymbolTable::readOMDSFile(const QString& filename)
+{
+	QFile file(filename);
+	if (!file.open(QFile::ReadOnly | QFile::Text)) {
+		return false;
+	}
+
+	QXmlStreamReader ses;
+	ses.setDevice(&file);
+	loadSymbols(ses);
 	return true;
 }
 bool SymbolTable::readTNIASM0File(const QString& filename)

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -81,6 +81,7 @@ class SymbolTable : public QObject
 public:
 	enum FileType {
 		DETECT_FILE,
+		OMDS_FILE,
 		TNIASM0_FILE,
 		TNIASM1_FILE,
 		SJASM_FILE,
@@ -131,6 +132,7 @@ private:
 	void appendFile(const QString& file, FileType type);
 	bool readSymbolFile(
 		const QString& filename, FileType type, const QString& equ);
+	bool readOMDSFile(const QString& filename);
 	bool readTNIASM0File(const QString& filename);
 	bool readTNIASM1File(const QString& filename);
 	bool readASMSXFile(const QString& filename);


### PR DESCRIPTION
Having the Session Manager read OMDS files allows us to import symbols, breakpoints and watchpoints from other projects. You can, for instance, maintain an OMDS file containing only BIOS symbols for several different debugging sessions. And you will not need to adjust the symbol slots/subslots ever again.