### PR TITLE
Reverting error on fa86112c06c790f936e9e68af17cdd1c5e06cb65

### DIFF
--- a/src/VramTiledView.cpp
+++ b/src/VramTiledView.cpp
@@ -511,6 +511,8 @@ std::optional<VramTiledView::MouseEventInfo> VramTiledView::infoFromMouseEvent(Q
 	if (x >= horiStep * screenWidth) return {};
 	if (y >= 8 * screenHeight) return {};
 
+	x = int(x / horiStep);
+	y = int(y / 8);
 	int character = 0;
 	switch (tableToShow) {
 		case 0:


### PR DESCRIPTION
Wrong tile coordinate in TileViewer.