### PR TITLE
refresh open BitmapViewer before connected

### DIFF
--- a/src/BitMapViewer.cpp
+++ b/src/BitMapViewer.cpp
@@ -65,12 +65,13 @@ BitMapViewer::BitMapViewer(QWidget* parent)
 	useVDP = useVDPRegisters->isChecked();
 
 	const unsigned char* vram    = VDPDataStore::instance().getVramPointer();
-	const unsigned char* palette = VDPDataStore::instance().getPalettePointer();
 	imageWidget->setVramSource(vram);
 	imageWidget->setVramAddress(0);
-	imageWidget->setPaletteSource(palette);
+	// Palette data not received from VDPDataStore yet causing black image, so
+	// we start by using fixed palette until VDPDataStoreDataRefreshed kicks in.
+	imageWidget->setPaletteSource(currentPalette);
 	
-	//now hook up some signals and slots
+	// now hook up some signals and slots
 	connect(&VDPDataStore::instance(), &VDPDataStore::dataRefreshed,
 	        this, &BitMapViewer::VDPDataStoreDataRefreshed);
 	connect(&VDPDataStore::instance(), &VDPDataStore::dataRefreshed,
@@ -161,6 +162,9 @@ void BitMapViewer::decodeVDPregs()
 	if (useVDP) {
 		screenMode->setCurrentIndex(bits_mode[v3]);
 		updateDisplayAsFrame();
+	}
+	if (useVDPPalette) {
+		imageWidget->setPaletteSource(VDPDataStore::instance().getPalettePointer());
 	}
 
 	// Get the current visible page

--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -1219,6 +1219,7 @@ void DebuggerForm::toggleBitMappedDisplay()
 	dw->setDestroyable(true);
 	dw->setMovable(true);
 	dw->setClosable(true);
+
 	/*
 	connect(dw, &DockableWidget::visibilityChanged,
 	        this, &DebuggerForm::dockWidgetVisibilityChanged);
@@ -1226,7 +1227,8 @@ void DebuggerForm::toggleBitMappedDisplay()
 	        viewer, &BitMapViewer::setDebuggables);
 	*/
 
-	// TODO: refresh should be being hanled by VDPDataStore...
+	// TODO: refresh should be handled by VDPDataStore...
+	connect(this, &DebuggerForm::connected, viewer, &BitMapViewer::refresh);
 	connect(this, &DebuggerForm::breakStateEntered, viewer, &BitMapViewer::refresh);
 
 	/*
@@ -1253,7 +1255,7 @@ void DebuggerForm::toggleCharMappedDisplay()
 	dw->setClosable(true);
 	//    dw->adjustSize();
 
-	// TODO: refresh should be being hanled by VDPDataStore...
+	// TODO: refresh should be handled by VDPDataStore...
 	connect(this, &DebuggerForm::breakStateEntered, viewer, &TileViewer::refresh);
 }
 
@@ -1273,7 +1275,7 @@ void DebuggerForm::toggleSpritesDisplay()
 	dw->setMovable(true);
 	dw->setClosable(true);
 
-	// TODO: refresh should be being hanled by VDPDataStore...
+	// TODO: refresh should be handled by VDPDataStore...
 	connect(this, &DebuggerForm::breakStateEntered, viewer, &SpriteViewer::refresh);
 }
 


### PR DESCRIPTION
Also fixed the black screen when BitmapViewer opens for the first time. This was caused by using an empty palette from VDPDataStore.