### PR TITLE
show just file name in SymbolManager instead of full path

### DIFF
--- a/src/SymbolManager.cpp
+++ b/src/SymbolManager.cpp
@@ -120,7 +120,9 @@ void SymbolManager::initFileList()
 	treeFiles->clear();
 	for (int i = 0; i < symTable.symbolFilesSize(); ++i) {
 		auto* item = new QTreeWidgetItem(treeFiles);
-		item->setText(FILENAME, symTable.symbolFile(i));
+		QFileInfo info(symTable.symbolFile(i));
+		item->setText(FILENAME, info.fileName());
+		item->setToolTip(FILENAME, symTable.symbolFile(i));
 		auto fmt = QLocale().dateTimeFormat(QLocale::ShortFormat);
 		createComboBox(i);
 		item->setText(LAST_REFRESH, symTable.symbolFileRefresh(i).toString(fmt));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7815819/215603762-489b8552-96dd-4139-bbb5-76ae4ed35111.png)
