### PR TITLE
"Edit palette..." disabled by default

### DIFF
--- a/src/BitMapViewer.ui
+++ b/src/BitMapViewer.ui
@@ -321,8 +321,11 @@
        </item>
        <item>
         <widget class="QPushButton" name="editPaletteButton" >
+         <property name="enabled" >
+          <bool>false</bool>
+         </property>
          <property name="text" >
-          <string>Edit palette..</string>
+          <string>Edit palette...</string>
          </property>
         </widget>
        </item>
@@ -422,7 +425,7 @@
      <widget class="QWidget" name="scrollAreaWidgetContents" >
       <property name="geometry" >
        <rect>
-        <x>85</x>
+        <x>82</x>
         <y>0</y>
         <width>508</width>
         <height>420</height>

--- a/src/SpriteViewer.ui
+++ b/src/SpriteViewer.ui
@@ -35,7 +35,7 @@
         <bool>false</bool>
        </property>
        <property name="text">
-        <string>Edit palette..</string>
+        <string>Edit palette...</string>
        </property>
       </widget>
      </item>

--- a/src/TileViewer.ui
+++ b/src/TileViewer.ui
@@ -964,7 +964,7 @@ NT: $196E (base+$16E)</string>
              <bool>false</bool>
             </property>
             <property name="text">
-             <string>Edit palette..</string>
+             <string>Edit palette...</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
BitmapViewer should open with "Edit Palette..." disabled by default because "Use VDP palette registers" is checked by default.