### PR TITLE
connected symbolFilesChanged to BreakpointViewer

### DIFF
--- a/src/BreakpointViewer.cpp
+++ b/src/BreakpointViewer.cpp
@@ -171,11 +171,11 @@ void BreakpointViewer::_createBreakpoint(BreakpointRef::Type type, int row)
 			// update breakpoint id
 			setTextField(type, row, ID, id);
 
-			selfUpdating = false;
+			disableRefresh = false;
 			emit contentsUpdated();
 		},
 		[this] (const QString& error) {
-			selfUpdating = false;
+			disableRefresh = false;
 			_handleSyncError(error);
 		}
 	);
@@ -189,8 +189,8 @@ void BreakpointViewer::replaceBreakpoint(BreakpointRef::Type type, int row)
 	auto* table = tables[type];
 	auto* item  = table->item(row, ID);
 	QString id  = item->text();
-	// remove and create breakpoint without calling sync in between.
-	selfUpdating = true;
+	// remove and create breakpoint without calling refresh in between.
+	disableRefresh = true;
 
 	// replacing is the same as removing an old breakpoint and then create a new one
 	const QString cmdStr = breakpoints->createRemoveCommand(id);
@@ -200,7 +200,7 @@ void BreakpointViewer::replaceBreakpoint(BreakpointRef::Type type, int row)
 		},
 		[this](const QString& error) {
 			// restore default behaviour on error
-			selfUpdating = false;
+			disableRefresh = false;
 			_handleSyncError(error);
 		}
 	);
@@ -271,7 +271,7 @@ void BreakpointViewer::_createCondition(int row)
 			// update breakpoint id
 			setTextField(type, row, ID, id);
 			// restore default behaviour if replacing a Breakpoint
-			selfUpdating = false;
+			disableRefresh = false;
 		},
 		[this] (const QString& error) { _handleSyncError(error); }
 	);
@@ -593,10 +593,10 @@ std::optional<int> BreakpointViewer::findTableRowByIndex(BreakpointRef::Type typ
 	return {};
 }
 
-void BreakpointViewer::sync()
+void BreakpointViewer::refresh()
 {
 	// don't reload if self-inflicted update
-	if (selfUpdating) return;
+	if (disableRefresh) return;
 
 	// store unused items position by disabling ordering
 	disableSorting();

--- a/src/BreakpointViewer.h
+++ b/src/BreakpointViewer.h
@@ -41,7 +41,7 @@ public:
 
 	void setRunState();
 	void setBreakState();
-	void sync();
+	void refresh();
 
 signals:
 	void contentsUpdated();
@@ -102,7 +102,7 @@ private:
 	QTableWidget* tables[BreakpointRef::ALL];
 	std::map<QString, BreakpointRef> maps[BreakpointRef::ALL];
 
-	bool selfUpdating = false;
+	bool disableRefresh = false;
 	bool userMode = true;
 	bool runState;
 	bool conditionsMsg = false;

--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -686,7 +686,7 @@ void DebuggerForm::createForm()
 	connect(slotView, &SlotViewer::slotsUpdated, this, &DebuggerForm::onSlotsUpdated);
 
 	// Breakpoint viewer
-	connect(this, &DebuggerForm::breakpointsUpdated, bpView, &BreakpointViewer::sync);
+	connect(this, &DebuggerForm::breakpointsUpdated, bpView, &BreakpointViewer::refresh);
 	connect(this, &DebuggerForm::runStateEntered, bpView, &BreakpointViewer::setRunState);
 	connect(this, &DebuggerForm::breakStateEntered, bpView, &BreakpointViewer::setBreakState);
 	connect(bpView, &BreakpointViewer::contentsUpdated, this, [this]{ reloadBreakpoints(false); });
@@ -1114,6 +1114,8 @@ void DebuggerForm::systemSymbolManager()
 	        bpView, &BreakpointViewer::onSymbolTableChanged);
 	connect(this, &DebuggerForm::symbolFilesChanged,
 	        symManager, &SymbolManager::refresh);
+	connect(this, &DebuggerForm::symbolFilesChanged,
+	        bpView, &BreakpointViewer::refresh);
 	symManager->exec();
 
 	emit symbolsChanged();


### PR DESCRIPTION
This will allow BreakpointViewer to refresh automatically when a symbol file change is detected.

Also:
* BreakpointViewer: renamed sync to refresh to be more compliant with other widgets;
* selfUpdating renamed to disableRefresh;