### PR TITLE
Added preferences option to preserve breakpoint connected to symbol…

### DIFF
--- a/src/BreakpointViewer.cpp
+++ b/src/BreakpointViewer.cpp
@@ -24,7 +24,7 @@ enum TableColumns {
 	T_CONDITION = 3,
 	SLOT = 4,
 	SEGMENT = 5,
-	ID = 6,
+	BREAKPOINT_ID = 6,
 	TABLE_INDEX = 7,
 };
 
@@ -53,7 +53,7 @@ BreakpointViewer::BreakpointViewer(DebugSession& session, QWidget* parent)
 	bpTableWidget->horizontalHeader()->setHighlightSections(false);
 	bpTableWidget->sortByColumn(LOCATION, Qt::AscendingOrder);
 	bpTableWidget->setColumnHidden(WP_TYPE, true);
-	bpTableWidget->setColumnHidden(ID, true);
+	bpTableWidget->setColumnHidden(BREAKPOINT_ID, true);
 	bpTableWidget->setColumnHidden(TABLE_INDEX, true);
 	bpTableWidget->resizeColumnsToContents();
 	bpTableWidget->setSortingEnabled(true);
@@ -63,7 +63,7 @@ BreakpointViewer::BreakpointViewer(DebugSession& session, QWidget* parent)
 	        &BreakpointViewer::on_headerClicked);
 
 	wpTableWidget->horizontalHeader()->setHighlightSections(false);
-	wpTableWidget->setColumnHidden(ID, true);
+	wpTableWidget->setColumnHidden(BREAKPOINT_ID, true);
 	wpTableWidget->setColumnHidden(TABLE_INDEX, true);
 	wpTableWidget->sortByColumn(WP_REGION, Qt::AscendingOrder);
 	wpTableWidget->resizeColumnsToContents();
@@ -73,7 +73,7 @@ BreakpointViewer::BreakpointViewer(DebugSession& session, QWidget* parent)
 
 	cnTableWidget->horizontalHeader()->setHighlightSections(false);
 	cnTableWidget->setColumnHidden(WP_TYPE, true);
-	cnTableWidget->setColumnHidden(ID, true);
+	cnTableWidget->setColumnHidden(BREAKPOINT_ID, true);
 	cnTableWidget->setColumnHidden(LOCATION, true);
 	cnTableWidget->setColumnHidden(SLOT, true);
 	cnTableWidget->setColumnHidden(SEGMENT, true);
@@ -169,7 +169,7 @@ void BreakpointViewer::_createBreakpoint(BreakpointRef::Type type, int row)
 			addBreakpointRef(id, newRef);
 
 			// update breakpoint id
-			setTextField(type, row, ID, id);
+			setTextField(type, row, BREAKPOINT_ID, id);
 
 			disableRefresh = false;
 			emit contentsUpdated();
@@ -187,7 +187,7 @@ void BreakpointViewer::_createBreakpoint(BreakpointRef::Type type, int row)
 void BreakpointViewer::replaceBreakpoint(BreakpointRef::Type type, int row)
 {
 	auto* table = tables[type];
-	auto* item  = table->item(row, ID);
+	auto* item  = table->item(row, BREAKPOINT_ID);
 	QString id  = item->text();
 	// remove and create breakpoint without calling refresh in between.
 	disableRefresh = true;
@@ -213,7 +213,7 @@ void BreakpointViewer::removeBreakpoint(BreakpointRef::Type type, int row, bool 
 {
 	auto* table = tables[type];
 
-	auto* item  = table->item(row, ID);
+	auto* item  = table->item(row, BREAKPOINT_ID);
 	assert(!item->text().isEmpty());
 	QString id  = item->text();
 	const QString cmdStr = Breakpoints::createRemoveCommand(id);
@@ -269,7 +269,7 @@ void BreakpointViewer::_createCondition(int row)
 			setBreakpointChecked(type, row, Qt::Checked);
 
 			// update breakpoint id
-			setTextField(type, row, ID, id);
+			setTextField(type, row, BREAKPOINT_ID, id);
 			// restore default behaviour if replacing a Breakpoint
 			disableRefresh = false;
 		},
@@ -480,7 +480,7 @@ void BreakpointViewer::changeTableItem(BreakpointRef::Type type, QTableWidgetIte
 			if (!enabled) return;
 			break;
 		}
-		case ID:
+		case BREAKPOINT_ID:
 			return;
 		default:
 			qWarning() << "Unknown table column" << table->column(item);
@@ -675,7 +675,7 @@ void BreakpointViewer::refresh()
 BreakpointRef* BreakpointViewer::findBreakpointRef(BreakpointRef::Type type, int row)
 {
 	auto& table = tables[type];
-	auto* item = table->item(row, ID);
+	auto* item = table->item(row, BREAKPOINT_ID);
 	auto it = maps[type].find(item->text());
 	if (it != maps[type].end()) return &it->second;
 	return nullptr;
@@ -771,11 +771,11 @@ int BreakpointViewer::createTableRow(BreakpointRef::Type type, int row)
 	item5->setText("X");
 	table->setItem(row, SEGMENT, item5);
 
-	// breakpoint ID
+	// breakpoint id
 	auto* item6 = new QTableWidgetItem();
 	item6->setFlags(Qt::NoItemFlags);
 	item6->setText("");
-	table->setItem(row, ID, item6);
+	table->setItem(row, BREAKPOINT_ID, item6);
 
 	// tableIndex
 	auto* item7 = new QTableWidgetItem();
@@ -841,7 +841,7 @@ void BreakpointViewer::fillTableRow(BreakpointRef::Type type, int row, int bpInd
 	item5->setText(segment);
 
 	// id
-	auto* item6 = table->item(row, ID);
+	auto* item6 = table->item(row, BREAKPOINT_ID);
 	item6->setText(bp.id);
 }
 

--- a/src/BreakpointViewer.h
+++ b/src/BreakpointViewer.h
@@ -12,9 +12,10 @@ class QPaintEvent;
 class Breakpoints;
 class DebugSession;
 
-struct BreakpointRef {
-	enum Type { BREAKPOINT, WATCHPOINT, CONDITION, ALL } type;
+enum BreakpointType { BREAKPOINT, WATCHPOINT, CONDITION, ALL };
 
+struct BreakpointRef {
+	enum BreakpointType type;
 	QString id;
 	int tableIndex = -1;
 	int breakpointIndex = -1;
@@ -47,48 +48,48 @@ signals:
 	void contentsUpdated();
 
 private:
-	void setTextField(BreakpointRef::Type type, int row, int column, const QString& value, const QString& tooltip = {});
+	void setTextField(BreakpointType type, int row, int column, const QString& value, const QString& tooltip = {});
 
 	std::optional<AddressRange> parseSymbolOrValue(const QString& field) const;
 
 	QString findSymbolOrValue(uint16_t address) const;
 
 	std::optional<AddressRange> parseLocationField(std::optional<int> bpIndex,
-	                                               BreakpointRef::Type type,
+	                                               BreakpointType type,
 	                                               const QString& field,
 	                                               const QString& combo = {});
 	Slot parseSlotField(std::optional<int> bpIndex, const QString& field);
 	std::optional<uint8_t> parseSegmentField(std::optional<int> bpIndex, const QString& field);
-	void changeTableItem(BreakpointRef::Type type, QTableWidgetItem* item);
+	void changeTableItem(BreakpointType type, QTableWidgetItem* item);
 	void createComboBox(int row);
 	Breakpoint::Type readComboBox(int row);
-	int  createTableRow(BreakpointRef::Type type, int row = -1);
-	void fillTableRowLocation(BreakpointRef::Type type, int row, const QString& location);
-	void fillTableRow(BreakpointRef::Type type, int row, int bpIndex);
-	std::optional<Breakpoint> parseTableRow(BreakpointRef::Type type, int row);
+	int  createTableRow(BreakpointType type, int row = -1);
+	void fillTableRowLocation(BreakpointType type, int row, const QString& location);
+	void fillTableRow(BreakpointType type, int row, int bpIndex);
+	std::optional<Breakpoint> parseTableRow(BreakpointType type, int row);
 	bool addBreakpointRef(const QString& id, BreakpointRef& data);
 
-	std::optional<int> getTableIndexByRow(BreakpointRef::Type type, int row) const;
-	void createBreakpoint(BreakpointRef::Type type, int row);
+	std::optional<int> getTableIndexByRow(BreakpointType type, int row) const;
+	void createBreakpoint(BreakpointType type, int row);
 	void _handleSyncError(const QString& error);
 	void _handleKeyAlreadyExists();
 	void _handleKeyNotFound();
-	void _createBreakpoint(BreakpointRef::Type type, int row);
+	void _createBreakpoint(BreakpointType type, int row);
 	void _createCondition(int row);
 
-	void replaceBreakpoint(BreakpointRef::Type type, int row);
-	void removeBreakpoint(BreakpointRef::Type type, int row, bool removeLocal = false);
-	void setBreakpointChecked(BreakpointRef::Type type, int row, Qt::CheckState state);
-	void onAddBtnClicked(BreakpointRef::Type type);
-	void onRemoveBtnClicked(BreakpointRef::Type type);
-	void stretchTable(BreakpointRef::Type type = BreakpointRef::ALL);
+	void replaceBreakpoint(BreakpointType type, int row);
+	void removeBreakpoint(BreakpointType type, int row, bool removeLocal = false);
+	void setBreakpointChecked(BreakpointType type, int row, Qt::CheckState state);
+	void onAddBtnClicked(BreakpointType type);
+	void onRemoveBtnClicked(BreakpointType type);
+	void stretchTable(BreakpointType type = BreakpointType::ALL);
 
-	std::optional<int> findTableRowByIndex(BreakpointRef::Type type, int index) const;
-	BreakpointRef* findBreakpointRef(BreakpointRef::Type type, int row);
-	BreakpointRef* findBreakpointRefById(BreakpointRef::Type type, const QString& id);
+	std::optional<int> findTableRowByIndex(BreakpointType type, int index) const;
+	BreakpointRef* findBreakpointRef(BreakpointType type, int row);
+	BreakpointRef* findBreakpointRefById(BreakpointType type, const QString& id);
 
 	void changeCurrentWpType(int row, int index);
-	void disableSorting(BreakpointRef::Type type = BreakpointRef::ALL);
+	void disableSorting(BreakpointType type = BreakpointType::ALL);
 	void changeBpTableItem(QTableWidgetItem* item);
 	void changeWpTableItem(QTableWidgetItem* item);
 	void changeCnTableItem(QTableWidgetItem* item);
@@ -99,8 +100,8 @@ private:
 	Ui::BreakpointViewer* ui;
 	DebugSession& debugSession;
 
-	QTableWidget* tables[BreakpointRef::ALL];
-	std::map<QString, BreakpointRef> maps[BreakpointRef::ALL];
+	QTableWidget* tables[BreakpointType::ALL];
+	std::map<QString, BreakpointRef> maps[BreakpointType::ALL];
 
 	bool disableRefresh = false;
 	bool userMode = true;

--- a/src/BreakpointViewer.h
+++ b/src/BreakpointViewer.h
@@ -14,17 +14,6 @@ class DebugSession;
 
 enum BreakpointType { BREAKPOINT, WATCHPOINT, CONDITION, ALL };
 
-struct BreakpointRef {
-	enum BreakpointType type;
-	QString id;
-	int tableIndex = -1;
-	int breakpointIndex = -1;
-
-	bool operator==(const QString &id_) const {
-		return id_ == id;
-	}
-};
-
 class BreakpointViewer : public QTabWidget, private Ui::BreakpointViewer
 {
 	Q_OBJECT
@@ -63,11 +52,10 @@ private:
 	void changeTableItem(BreakpointType type, QTableWidgetItem* item);
 	void createComboBox(int row);
 	Breakpoint::Type readComboBox(int row);
-	int  createTableRow(BreakpointType type, int row = -1);
+	int createTableRow(BreakpointType type, int row = -1);
 	void fillTableRowLocation(BreakpointType type, int row, const QString& location);
 	void fillTableRow(BreakpointType type, int row, int bpIndex);
 	std::optional<Breakpoint> parseTableRow(BreakpointType type, int row);
-	bool addBreakpointRef(const QString& id, BreakpointRef& data);
 
 	std::optional<int> getTableIndexByRow(BreakpointType type, int row) const;
 	void createBreakpoint(BreakpointType type, int row);
@@ -84,9 +72,8 @@ private:
 	void onRemoveBtnClicked(BreakpointType type);
 	void stretchTable(BreakpointType type = BreakpointType::ALL);
 
-	std::optional<int> findTableRowByIndex(BreakpointType type, int index) const;
-	BreakpointRef* findBreakpointRef(BreakpointType type, int row);
-	BreakpointRef* findBreakpointRefById(BreakpointType type, const QString& id);
+	std::optional<int> findBreakpointIndex(BreakpointType type, int row) const;
+	std::optional<int> findBreakpointRow(BreakpointType type, const QString& id) const;
 
 	void changeCurrentWpType(int row, int index);
 	void disableSorting(BreakpointType type = BreakpointType::ALL);
@@ -95,13 +82,13 @@ private:
 	void changeCnTableItem(QTableWidgetItem* item);
 	void on_itemPressed(QTableWidgetItem* item);
 	void on_headerClicked(int index);
+	void refreshTableRow(int bpIndex, BreakpointType type, int row);
 
 private:
 	Ui::BreakpointViewer* ui;
 	DebugSession& debugSession;
 
 	QTableWidget* tables[BreakpointType::ALL];
-	std::map<QString, BreakpointRef> maps[BreakpointType::ALL];
 
 	bool disableRefresh = false;
 	bool userMode = true;

--- a/src/BreakpointViewer.ui
+++ b/src/BreakpointViewer.ui
@@ -117,7 +117,7 @@
       </column>
       <column>
        <property name="text">
-        <string>Index</string>
+        <string>Address</string>
        </property>
       </column>
      </widget>
@@ -244,7 +244,7 @@
       </column>
       <column>
        <property name="text">
-        <string>Index</string>
+        <string>Address</string>
        </property>
       </column>
      </widget>
@@ -371,7 +371,7 @@
       </column>
       <column>
        <property name="text">
-        <string>Index</string>
+        <string>Address</string>
        </property>
       </column>
      </widget>

--- a/src/Dasm.h
+++ b/src/Dasm.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 class SymbolTable;
 struct MemoryLayout;

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -42,6 +42,11 @@ void PreferencesDialog::initConfig()
 	cbPreserveLostSymbols->setChecked(status2);
 	connect(cbPreserveLostSymbols, &QCheckBox::stateChanged,
 			this, &PreferencesDialog::preserveLostSymbols);
+
+	int status3 = s.preserveBreakpointSymbol() ? Qt::Checked : Qt::Unchecked;
+	cbPreserveBreakpointSymbol->setChecked(status3);
+	connect(cbPreserveBreakpointSymbol, &QCheckBox::stateChanged,
+			this, &PreferencesDialog::preserveBreakpointSymbol);
 }
 /*
  * Font settings
@@ -134,6 +139,11 @@ void PreferencesDialog::autoReloadSymbols(int state)
 void PreferencesDialog::preserveLostSymbols(int state)
 {
 	Settings::get().setPreserveLostSymbols(state == Qt::Checked);
+}
+
+void PreferencesDialog::preserveBreakpointSymbol(int state)
+{
+	Settings::get().setPreserveBreakpointSymbol(state == Qt::Checked);
 }
 
 void PreferencesDialog::setFontPreviewColor(const QColor& c)

--- a/src/PreferencesDialog.h
+++ b/src/PreferencesDialog.h
@@ -22,6 +22,7 @@ private:
 
 	void autoReloadSymbols(int state);
 	void preserveLostSymbols(int state);
+	void preserveBreakpointSymbol(int state);
 
 private:
 	bool updating;

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -1,7 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0" >
- <author></author>
- <comment></comment>
- <exportmacro></exportmacro>
  <class>PreferencesDialog</class>
  <widget class="QDialog" name="PreferencesDialog" >
   <property name="geometry" >
@@ -16,11 +14,20 @@
    <string>Preferences</string>
   </property>
   <layout class="QVBoxLayout" >
-   <property name="margin" >
-    <number>9</number>
-   </property>
    <property name="spacing" >
     <number>6</number>
+   </property>
+   <property name="leftMargin" >
+    <number>9</number>
+   </property>
+   <property name="topMargin" >
+    <number>9</number>
+   </property>
+   <property name="rightMargin" >
+    <number>9</number>
+   </property>
+   <property name="bottomMargin" >
+    <number>9</number>
    </property>
    <item>
     <widget class="QTabWidget" name="tabWidget" >
@@ -29,7 +36,7 @@
        <string>Symbol Table</string>
       </attribute>
       <widget class="QCheckBox" name="cbAutoReloadSymbols" >
-       <property name="geometry">
+       <property name="geometry" >
         <rect>
          <x>6</x>
          <y>6</y>
@@ -45,7 +52,7 @@
        </property>
       </widget>
       <widget class="QCheckBox" name="cbPreserveLostSymbols" >
-       <property name="geometry">
+       <property name="geometry" >
         <rect>
          <x>6</x>
          <y>38</y>
@@ -60,17 +67,45 @@
         <bool>true</bool>
        </property>
       </widget>
+      <widget class="QCheckBox" name="cbPreserveBreakpointSymbol" >
+       <property name="geometry" >
+        <rect>
+         <x>6</x>
+         <y>70</y>
+         <width>471</width>
+         <height>25</height>
+        </rect>
+       </property>
+       <property name="sizePolicy" >
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed" >
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text" >
+        <string>Preserve breakpoint when the symbol it points to changes address</string>
+       </property>
+      </widget>
      </widget>
      <widget class="QWidget" name="tabFonts" >
       <attribute name="title" >
        <string>Fonts</string>
       </attribute>
       <layout class="QHBoxLayout" >
-       <property name="margin" >
-        <number>9</number>
-       </property>
        <property name="spacing" >
         <number>6</number>
+       </property>
+       <property name="leftMargin" >
+        <number>9</number>
+       </property>
+       <property name="topMargin" >
+        <number>9</number>
+       </property>
+       <property name="rightMargin" >
+        <number>9</number>
+       </property>
+       <property name="bottomMargin" >
+        <number>9</number>
        </property>
        <item>
         <widget class="QListWidget" name="listFonts" >
@@ -81,19 +116,37 @@
        </item>
        <item>
         <layout class="QVBoxLayout" >
-         <property name="margin" >
-          <number>0</number>
-         </property>
          <property name="spacing" >
           <number>6</number>
          </property>
+         <property name="leftMargin" >
+          <number>0</number>
+         </property>
+         <property name="topMargin" >
+          <number>0</number>
+         </property>
+         <property name="rightMargin" >
+          <number>0</number>
+         </property>
+         <property name="bottomMargin" >
+          <number>0</number>
+         </property>
          <item>
           <layout class="QVBoxLayout" >
-           <property name="margin" >
-            <number>0</number>
-           </property>
            <property name="spacing" >
             <number>6</number>
+           </property>
+           <property name="leftMargin" >
+            <number>0</number>
+           </property>
+           <property name="topMargin" >
+            <number>0</number>
+           </property>
+           <property name="rightMargin" >
+            <number>0</number>
+           </property>
+           <property name="bottomMargin" >
+            <number>0</number>
            </property>
            <item>
             <widget class="QRadioButton" name="rbUseAppFont" >
@@ -129,18 +182,25 @@
          </item>
          <item>
           <layout class="QVBoxLayout" >
-           <property name="margin" >
-            <number>0</number>
-           </property>
            <property name="spacing" >
             <number>6</number>
+           </property>
+           <property name="leftMargin" >
+            <number>0</number>
+           </property>
+           <property name="topMargin" >
+            <number>0</number>
+           </property>
+           <property name="rightMargin" >
+            <number>0</number>
+           </property>
+           <property name="bottomMargin" >
+            <number>0</number>
            </property>
            <item>
             <widget class="QLabel" name="lblPreview" >
              <property name="sizePolicy" >
-              <sizepolicy>
-               <hsizetype>7</hsizetype>
-               <vsizetype>0</vsizetype>
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed" >
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
@@ -184,7 +244,7 @@
              <property name="orientation" >
               <enum>Qt::Vertical</enum>
              </property>
-             <property name="sizeHint" >
+             <property name="sizeHint" stdset="0" >
               <size>
                <width>20</width>
                <height>40</height>
@@ -202,18 +262,27 @@
    </item>
    <item>
     <layout class="QHBoxLayout" >
-     <property name="margin" >
-      <number>0</number>
-     </property>
      <property name="spacing" >
       <number>6</number>
+     </property>
+     <property name="leftMargin" >
+      <number>0</number>
+     </property>
+     <property name="topMargin" >
+      <number>0</number>
+     </property>
+     <property name="rightMargin" >
+      <number>0</number>
+     </property>
+     <property name="bottomMargin" >
+      <number>0</number>
      </property>
      <item>
       <spacer>
        <property name="orientation" >
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint" >
+       <property name="sizeHint" stdset="0" >
         <size>
          <width>131</width>
          <height>31</height>
@@ -232,7 +301,6 @@
    </item>
   </layout>
  </widget>
- <pixmapfunction></pixmapfunction>
  <resources/>
  <connections>
   <connection>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -3,7 +3,7 @@
 #include <QDebug>
 
 static const char* DebuggerConfigNames[Settings::CONFIG_END] = {
-	"AutoReloadSymbols", "PreserveLostSymbols"
+	"AutoReloadSymbols", "PreserveLostSymbols", "PreserveBreakpointSymbol"
 };
 
 static const char* DebuggerFontNames[Settings::FONT_END] = {
@@ -55,6 +55,7 @@ void Settings::getConfigFromSettings()
 {
 	getBoolFromSetting(AUTO_RELOAD_SYMBOLS, false);
 	getBoolFromSetting(PRESERVE_LOST_SYMBOLS, true);
+	getBoolFromSetting(PRESERVE_BREAKPOINT_SYMBOL, false);
 }
 
 void Settings::setConfig(DebuggerConfig c, const QVariant& v)
@@ -189,6 +190,16 @@ bool Settings::preserveLostSymbols() const
 void Settings::setPreserveLostSymbols(bool b)
 {
 	setConfig(PRESERVE_LOST_SYMBOLS, b);
+}
+
+bool Settings::preserveBreakpointSymbol() const
+{
+	return config[PRESERVE_BREAKPOINT_SYMBOL].value<bool>();
+}
+
+void Settings::setPreserveBreakpointSymbol(bool b)
+{
+	setConfig(PRESERVE_BREAKPOINT_SYMBOL, b);
 }
 
 void Settings::updateFonts()

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -10,7 +10,8 @@ class Settings : public QSettings
 	Q_OBJECT
 public:
 	enum DebuggerConfig {
-		AUTO_RELOAD_SYMBOLS, PRESERVE_LOST_SYMBOLS, CONFIG_END
+		AUTO_RELOAD_SYMBOLS, PRESERVE_LOST_SYMBOLS, PRESERVE_BREAKPOINT_SYMBOL,
+		CONFIG_END
 	};
 	enum DebuggerFont {
 		APP_FONT, FIXED_FONT, CODE_FONT, LABEL_FONT, HEX_FONT, FONT_END
@@ -33,6 +34,8 @@ public:
 	void setAutoReloadSymbols(bool b);
 	bool preserveLostSymbols() const;
 	void setPreserveLostSymbols(bool b);
+	bool preserveBreakpointSymbol() const;
+	void setPreserveBreakpointSymbol(bool b);
 	void setConfig(DebuggerConfig c, const QVariant& v);
 
 private:

--- a/src/SymbolTable.cpp
+++ b/src/SymbolTable.cpp
@@ -507,9 +507,12 @@ bool SymbolTable::readLinkMapFile(const QString& filename)
 	return true;
 }
 
-void SymbolTable::fileChanged(const QString & /*path*/)
+void SymbolTable::fileChanged(const QString& path)
 {
 	emit symbolFileChanged();
+	if (QFile::exists(path)) {
+		fileWatcher.addPath(path);
+	}
 }
 
 void SymbolTable::reloadFiles()


### PR DESCRIPTION
…name when symbol file changes.

This is useful when you are debugging your game or app and you need to make changes and build it again. Since symbols may change addresses, this feature updates the addresses that breakpoints point to.

![image](https://user-images.githubusercontent.com/7815819/233511955-aa281e6f-3663-41cd-951d-b4e70c52c969.png)

Extras:
* `disasmView` also updates symbols when symbol file changes;
* removed barely used `BreakpointRef`;