### PR TITLE
partial fix issue #21: DisasmViewer always reload on connect

### DIFF
--- a/src/DebuggerForm.cpp
+++ b/src/DebuggerForm.cpp
@@ -41,8 +41,6 @@
 #include <QCloseEvent>
 #include <iostream>
 
-bool forceBreak = false;
-
 class QueryPauseHandler : public SimpleCommand
 {
 public:
@@ -682,6 +680,7 @@ void DebuggerForm::createForm()
 
 	// Disasm viewer
 	connect(disasmView, &DisasmViewer::breakpointToggled, this, &DebuggerForm::toggleBreakpointAddress);
+	connect(this, &DebuggerForm::connected, disasmView, &DisasmViewer::refresh);
 	connect(this, &DebuggerForm::symbolsChanged, disasmView, &DisasmViewer::refresh);
 	connect(this, &DebuggerForm::settingsChanged, disasmView, &DisasmViewer::updateLayout);
 


### PR DESCRIPTION
Connecting to OpenMSX (for the first time only) triggers `onSlotUpdated`, which automatically refreshes the `disasmView`. So it will update twice. But I think this is barely noticeable.

Removed `forceBreak` that is not used anywhere.

This fixes issue #21 partially.