### PR TITLE
PaletteDialog: replace apply with restore defaults

### DIFF
--- a/src/BitMapViewer.cpp
+++ b/src/BitMapViewer.cpp
@@ -6,26 +6,7 @@
 #include <QMessageBox>
 
 
-// static to feed to PaletteDialog and be used when VDP colors aren't selected
-static uint8_t currentPalette[32] = {
-//    RB  G
-	0x00, 0,
-	0x00, 0,
-	0x11, 6,
-	0x33, 7,
-	0x17, 1,
-	0x27, 3,
-	0x51, 1,
-	0x27, 6,
-	0x71, 1,
-	0x73, 3,
-	0x61, 6,
-	0x64, 6,
-	0x11, 4,
-	0x65, 2,
-	0x55, 5,
-	0x77, 7,
-};
+static uint8_t currentPalette[32] = { 0 };
 
 BitMapViewer::BitMapViewer(QWidget* parent)
 	: QDialog(parent)
@@ -69,7 +50,7 @@ BitMapViewer::BitMapViewer(QWidget* parent)
 	imageWidget->setVramAddress(0);
 	// Palette data not received from VDPDataStore yet causing black image, so
 	// we start by using fixed palette until VDPDataStoreDataRefreshed kicks in.
-	imageWidget->setPaletteSource(currentPalette);
+	imageWidget->setPaletteSource(VDPDataStore::instance().getDefaultPalettePointer());
 	
 	// now hook up some signals and slots
 	connect(&VDPDataStore::instance(), &VDPDataStore::dataRefreshed,

--- a/src/PaletteDialog.cpp
+++ b/src/PaletteDialog.cpp
@@ -4,6 +4,7 @@
 #include <QPainter>
 #include "PaletteDialog.h"
 #include "Convert.h"
+#include "VDPDataStore.h"
 #include "ranges.h"
 
 
@@ -172,6 +173,15 @@ void PaletteDialog::syncToSource()
     emit paletteSynced();
 }
 
+void PaletteDialog::restoreDefaultPalette()
+{
+    memcpy(myPal, VDPDataStore::instance().getDefaultPalettePointer(), 32);
+    emit paletteChanged(myPal);
+    if (autoSync) {
+        syncToSource();
+    }
+}
+
 void PaletteDialog::setAutoSync(bool value)
 {
     if (autoSync == value) return;
@@ -199,8 +209,9 @@ void PaletteDialog::on_horizontalSlider_B_valueChanged(int value)
 
 void PaletteDialog::on_buttonBox_clicked(QAbstractButton* button)
 {
-    if (button== ui->buttonBox->button(QDialogButtonBox::Apply) ||
-        button== ui->buttonBox->button(QDialogButtonBox::Ok)) {
+    if (button== ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)) {
+        restoreDefaultPalette();
+    } else if (button== ui->buttonBox->button(QDialogButtonBox::Ok)) {
         syncToSource();
     } else if (button== ui->buttonBox->button(QDialogButtonBox::Reset) ||
                button== ui->buttonBox->button(QDialogButtonBox::Cancel)) {

--- a/src/PaletteDialog.cpp
+++ b/src/PaletteDialog.cpp
@@ -41,13 +41,11 @@ void PalettePatch::setHighlightTest(int colorNr)
 
 void PalettePatch::paintEvent(QPaintEvent* /*event*/)
 {
-	QPainter painter(this);
-	painter.setPen(isSelected ? Qt::white : QColor(myColor));
-	painter.setBrush(QBrush(myColor));
-	painter.drawRect(0, 0, this->width() - 1, this->height() - 1);
+    QPainter painter(this);
+    painter.setPen(isSelected ? Qt::white : QColor(myColor));
+    painter.setBrush(QBrush(myColor));
+    painter.drawRect(0, 0, this->width() - 1, this->height() - 1);
 }
-
-
 
 PaletteDialog::PaletteDialog(QWidget* parent)
     : QDialog(parent), ui(std::make_unique<Ui::PaletteDialog>())

--- a/src/PaletteDialog.h
+++ b/src/PaletteDialog.h
@@ -41,6 +41,7 @@ public:
     void setPalette(uint8_t* pal);
     uint8_t* getPalette();
     void syncToSource();
+    void restoreDefaultPalette();
     void setAutoSync(bool value);
 
 signals:

--- a/src/PaletteDialog.ui
+++ b/src/PaletteDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>513</width>
-    <height>271</height>
+    <height>278</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -139,7 +139,7 @@
         <enum>Qt::Horizontal</enum>
        </property>
        <property name="standardButtons">
-        <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Reset|QDialogButtonBox::RestoreDefaults</set>
        </property>
       </widget>
      </item>

--- a/src/TileViewer.cpp
+++ b/src/TileViewer.cpp
@@ -7,27 +7,7 @@
 #include <QMessageBox>
 
 
-// static to feed to PaletteDialog and be used when VDP colors aren't selected
-static uint8_t currentPalette[32] = {
-//    RB  G
-    0x00, 0,
-    0x00, 0,
-    0x11, 6,
-    0x33, 7,
-    0x17, 1,
-    0x27, 3,
-    0x51, 1,
-    0x27, 6,
-    0x71, 1,
-    0x73, 3,
-    0x61, 6,
-    0x64, 6,
-    0x11, 4,
-    0x65, 2,
-    0x55, 5,
-    0x77, 7,
-};
-
+static uint8_t currentPalette[32] = { 0 };
 
 TileViewer::TileViewer(QWidget* parent)
     : QDialog(parent), image4label(32, 32, QImage::Format_RGB32)
@@ -82,7 +62,7 @@ TileViewer::TileViewer(QWidget* parent)
 
     scrollArea->setWidget(imageWidget);
 
-    imageWidget->setPaletteSource(currentPalette);
+    imageWidget->setPaletteSource(VDPDataStore::instance().getDefaultPalettePointer());
     imageWidget->setUseBlink(cb_blinkcolors->isChecked());
     imageWidget->setDrawGrid(cb_drawgrid->isChecked());
 

--- a/src/VDPDataStore.cpp
+++ b/src/VDPDataStore.cpp
@@ -1,6 +1,27 @@
 #include "VDPDataStore.h"
 #include "CommClient.h"
 
+// static vector to feed PaletteDialog and be used when VDP colors aren't selected
+static const uint8_t defaultPalette[32] = {
+//    RB  G
+        0x00, 0,
+        0x00, 0,
+        0x11, 6,
+        0x33, 7,
+        0x17, 1,
+        0x27, 3,
+        0x51, 1,
+        0x27, 6,
+        0x71, 1,
+        0x73, 3,
+        0x61, 6,
+        0x64, 6,
+        0x11, 4,
+        0x65, 2,
+        0x55, 5,
+        0x77, 7,
+};
+
 class VDPDataStoreVersionCheck : public SimpleCommand
 {
 public:
@@ -148,6 +169,10 @@ void VDPDataStore::DataHexRequestReceived()
 const uint8_t* VDPDataStore::getVramPointer() const
 {
 	return &vram[0];
+}
+const uint8_t* VDPDataStore::getDefaultPalettePointer() const
+{
+	return defaultPalette;
 }
 const uint8_t* VDPDataStore::getPalettePointer() const
 {

--- a/src/VDPDataStore.h
+++ b/src/VDPDataStore.h
@@ -15,6 +15,7 @@ public:
 	static VDPDataStore& instance();
 
 	const uint8_t* getVramPointer() const;
+	const uint8_t* getDefaultPalettePointer() const;
 	const uint8_t* getPalettePointer() const;
 	const uint8_t* getRegsPointer() const;
 	const uint8_t* getStatusRegsPointer() const;


### PR DESCRIPTION
![image](https://github.com/openMSX/debugger/assets/7815819/c595cad2-816c-4610-a58c-f8855b13a8ca)

Now the palette editor allows the user to restore palette to the default MSX palette. `Apply` is not as useful as the `Defaults` button, so it was removed to reduce clutter.